### PR TITLE
Use non-locale aware type modifier %F in sprintf()

### DIFF
--- a/src/Knp/DoctrineBehaviors/DBAL/Types/PointType.php
+++ b/src/Knp/DoctrineBehaviors/DBAL/Types/PointType.php
@@ -63,6 +63,6 @@ class PointType extends Type
             return;
         }
 
-        return sprintf('(%f,%f)', $value->getLatitude(), $value->getLongitude());
+        return sprintf('(%F,%F)', $value->getLatitude(), $value->getLongitude());
     }
 }

--- a/src/Knp/DoctrineBehaviors/ORM/Geocodable/Type/Point.php
+++ b/src/Knp/DoctrineBehaviors/ORM/Geocodable/Type/Point.php
@@ -77,6 +77,6 @@ class Point
      */
     public function __toString()
     {
-        return sprintf('(%f,%f)', $this->latitude, $this->longitude);
+        return sprintf('(%F,%F)', $this->latitude, $this->longitude);
     }
 }


### PR DESCRIPTION
Using `%f` will lead to wrong formatted coordinates when using a locale which uses a comma as decimal separator (eg. with `setlocale(LC_NUMERIC, 'de_DE');`)
