### PR TITLE
Fixed removal of translations

### DIFF
--- a/src/Knp/DoctrineBehaviors/ORM/Translatable/TranslatableListener.php
+++ b/src/Knp/DoctrineBehaviors/ORM/Translatable/TranslatableListener.php
@@ -57,11 +57,12 @@ class TranslatableListener implements EventSubscriber
     {
         if (!$classMetadata->hasAssociation('translations')) {
             $classMetadata->mapOneToMany([
-                'fieldName'    => 'translations',
-                'mappedBy'     => 'translatable',
-                'indexBy'      => 'locale',
-                'cascade'      => ['persist', 'merge', 'remove'],
-                'targetEntity' => $classMetadata->name.'Translation'
+                'fieldName'     => 'translations',
+                'mappedBy'      => 'translatable',
+                'indexBy'       => 'locale',
+                'cascade'       => ['persist', 'merge', 'remove'],
+                'targetEntity'  => $classMetadata->name.'Translation',
+                'orphanRemoval' => true
             ]);
         }
     }

--- a/tests/Knp/DoctrineBehaviors/ORM/TranslatableTest.php
+++ b/tests/Knp/DoctrineBehaviors/ORM/TranslatableTest.php
@@ -148,4 +148,26 @@ class TranslatableTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('fabuleux3', $entity->translate('fr')->getTitle());
         $this->assertEquals(spl_object_hash($entity->translate('fr')), spl_object_hash($translation));
     }
+
+    /**
+     * @test
+     */
+    public function should_remove_translation()
+    {
+        $em = $this->getEntityManager();
+
+        $entity = new \BehaviorFixtures\ORM\TranslatableEntity();
+        $entity->translate('en')->setTitle('Hello');
+        $entity->translate('nl')->setTitle('Hallo');
+        $entity->mergeNewTranslations();
+        $em->persist($entity);
+        $em->flush();
+
+        $nlTranslation = $entity->translate('nl');
+        $entity->removeTranslation($nlTranslation);
+        $em->flush();
+
+        $em->refresh($entity);
+        $this->assertNotEquals('Hallo', $entity->translate('nl')->getTitle());
+    }
 }


### PR DESCRIPTION
Removed translations weren't actually removed from the database, added orphanRemoval=true to fix this.
