### PR TITLE
Fixed SoftDeletable behavior when using inheritance

### DIFF
--- a/src/Knp/DoctrineBehaviors/ORM/SoftDeletable/SoftDeletableListener.php
+++ b/src/Knp/DoctrineBehaviors/ORM/SoftDeletable/SoftDeletableListener.php
@@ -63,7 +63,7 @@ class SoftDeletableListener extends AbstractListener
      */
     private function isEntitySupported(ClassMetadata $classMetadata)
     {
-        return $this->getClassAnalyzer()->hasTrait($classMetadata->reflClass, 'Knp\DoctrineBehaviors\Model\SoftDeletable\SoftDeletable');
+        return $this->getClassAnalyzer()->hasTrait($classMetadata->reflClass, 'Knp\DoctrineBehaviors\Model\SoftDeletable\SoftDeletable', true);
     }
 
     /**

--- a/tests/Knp/DoctrineBehaviors/ORM/SoftDeletableTest.php
+++ b/tests/Knp/DoctrineBehaviors/ORM/SoftDeletableTest.php
@@ -84,6 +84,20 @@ class SoftDeletableTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNotNull($entity);
         $this->assertTrue($entity->isDeleted());
+    }
 
+    public function testDeleteInheritance()
+    {
+        $em = $this->getEntityManager();
+
+        $entity = new \BehaviorFixtures\ORM\DeletableEntityInherit();
+
+        $em->persist($entity);
+        $em->flush();
+
+        $em->remove($entity);
+        $em->flush();
+
+        $this->assertTrue($entity->isDeleted());
     }
 }

--- a/tests/fixtures/BehaviorFixtures/ORM/DeletableEntity.php
+++ b/tests/fixtures/BehaviorFixtures/ORM/DeletableEntity.php
@@ -7,6 +7,11 @@ use Knp\DoctrineBehaviors\Model;
 
 /**
  * @ORM\Entity
+ * @ORM\InheritanceType("SINGLE_TABLE")
+ * @ORM\DiscriminatorMap({
+ *     "mainclass" = "BehaviorFixtures\ORM\DeletableEntity",
+ *     "subclass" = "BehaviorFixtures\ORM\DeletableEntityInherit"
+ * })
  */
 class DeletableEntity
 {

--- a/tests/fixtures/BehaviorFixtures/ORM/DeletableEntityInherit.php
+++ b/tests/fixtures/BehaviorFixtures/ORM/DeletableEntityInherit.php
@@ -2,6 +2,8 @@
 
 namespace BehaviorFixtures\ORM;
 
+use Doctrine\ORM\Mapping as ORM;
+
 /**
  * @ORM\Entity
  */


### PR DESCRIPTION
Subclasses of classes with the SoftDeletable trait were skipped in the listener because the recursive flag was not set when calling 'hasTrait'.
