### PR TITLE
Fix Geocodable listener isEntitySupported check

### DIFF
--- a/src/Knp/DoctrineBehaviors/ORM/Geocodable/GeocodableListener.php
+++ b/src/Knp/DoctrineBehaviors/ORM/Geocodable/GeocodableListener.php
@@ -146,7 +146,7 @@ class GeocodableListener extends AbstractListener
      */
     private function isEntitySupported(\ReflectionClass $reflClass)
     {
-        return $this->getClassAnalyzer()->hasMethod($reflClass, 'getLocation');
+        return $this->getClassAnalyzer()->hasTrait($reflClass, 'Knp\DoctrineBehaviors\Model\Geocodable\Geocodable');
     }
 
     public function getSubscribedEvents()


### PR DESCRIPTION
This fix this issue : if the entity has a `location` field but do not use the Geocodable trait, the listener hooks will be executed anyway.
