### PR TITLE
Semantic versioning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,5 +31,10 @@
     "autoload": {
         "psr-0": { "Knp\\DoctrineBehaviors": "src/" }
     },
-    "minimum-stability": "dev"
+    "minimum-stability": "dev",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0.x-dev"
+        }
+    }
 }


### PR DESCRIPTION
This library lacks semantic versioning. This is a problem when updates introduce BC breaks or require changes to the schema, for example the change to the Blameable trait also including a deletedBy field.

Therefore, I added the branch-alias to the composer.json, allowing users to require this package in a safer way (as long as the version is bumped with (potential) BC breaks in the future) than requiring dev-master.
