### PR TITLE
Error serializing the AbstractToken in Symfony2

### DIFF
--- a/src/Knp/DoctrineBehaviors/Model/Translatable/TranslatableProperties.php
+++ b/src/Knp/DoctrineBehaviors/Model/Translatable/TranslatableProperties.php
@@ -22,17 +22,17 @@ trait TranslatableProperties
      * Will be mapped to translatable entity
      * by TranslatableListener
      */
-    private $translations;
+    protected $translations;
 
     /**
      * Will be merged with persisted translations on mergeNewTranslations call
      *
      * @see mergeNewTranslations
      */
-    private $newTranslations;
+    protected $newTranslations;
 
     /**
      * currentLocale is a non persisted field configured during postLoad event
      */
-    private $currentLocale;
+    protected $currentLocale;
 }


### PR DESCRIPTION
I have my Entity User with a relation with a table that is Translatable. 

The problem is that Symfony2 try to serialize the Entity and the other Entity, because there is a OneToOne relation between them.

There is a reported issue, that Doctrine2 have problems serializing private properties. So i have changed the private properties into protected ones.
