### PR TITLE
Remove @constructor annotations

### DIFF
--- a/src/Knp/DoctrineBehaviors/ORM/Blameable/BlameableListener.php
+++ b/src/Knp/DoctrineBehaviors/ORM/Blameable/BlameableListener.php
@@ -46,8 +46,6 @@ class BlameableListener extends AbstractListener
     private $userEntity;
 
     /**
-     * @constructor
-     *
      * @param callable
      * @param string $userEntity
      */

--- a/src/Knp/DoctrineBehaviors/ORM/Blameable/UserCallable.php
+++ b/src/Knp/DoctrineBehaviors/ORM/Blameable/UserCallable.php
@@ -24,8 +24,6 @@ class UserCallable
     private $container;
 
     /**
-     * @constructor
-     *
      * @param callable
      * @param string $userEntity
      */

--- a/src/Knp/DoctrineBehaviors/ORM/Geocodable/GeocodableListener.php
+++ b/src/Knp/DoctrineBehaviors/ORM/Geocodable/GeocodableListener.php
@@ -39,8 +39,6 @@ class GeocodableListener extends AbstractListener
     private $geolocationCallable;
 
     /**
-     * @constructor
-     *
      * @param callable
      */
     public function __construct(ClassAnalyzer $classAnalyzer, callable $geolocationCallable = null)

--- a/src/Knp/DoctrineBehaviors/ORM/Loggable/LoggableListener.php
+++ b/src/Knp/DoctrineBehaviors/ORM/Loggable/LoggableListener.php
@@ -33,8 +33,6 @@ class LoggableListener extends AbstractListener
     private $loggerCallable;
 
     /**
-     * @constructor
-     *
      * @param callable
      */
     public function __construct(ClassAnalyzer $classAnalyzer, callable $loggerCallable)

--- a/src/Knp/DoctrineBehaviors/ORM/Loggable/LoggerCallable.php
+++ b/src/Knp/DoctrineBehaviors/ORM/Loggable/LoggerCallable.php
@@ -24,8 +24,6 @@ class LoggerCallable
     private $logger;
 
     /**
-     * @constructor
-     *
      * @param LoggerInterface $logger
      */
     public function __construct(LoggerInterface $logger)


### PR DESCRIPTION
Removed the `@constructor` annotations. It's not an official phpdoc tag, and is therefore not ignored by doctrine/annotations, causing it to throw exceptions when it tries to parse these classes (in my case when using JMSSecurityExtraBundle).
