### PR TITLE
Bugfix: properties visibility changed

### DIFF
--- a/src/Knp/DoctrineBehaviors/Model/Blameable/Blameable.php
+++ b/src/Knp/DoctrineBehaviors/Model/Blameable/Blameable.php
@@ -24,17 +24,17 @@ trait Blameable
      * Will be mapped to either string or user entity
      * by BlameableListener
      */
-    private $createdBy;
+    protected $createdBy;
 
     /**
      * Will be mapped to either string or user entity
      * by BlameableListener
      */
-    private $updatedBy;
+    protected $updatedBy;
 
     /**
      * Will be mapped to either string or user entity
      * by BlameableListener
      */
-    private $deletedBy;
+    protected $deletedBy;
 }

--- a/src/Knp/DoctrineBehaviors/Model/Geocodable/Geocodable.php
+++ b/src/Knp/DoctrineBehaviors/Model/Geocodable/Geocodable.php
@@ -23,7 +23,7 @@ trait Geocodable
     /**
      * @ORM\Column(type="point", nullable=true)
      */
-    private $location;
+    protected $location;
 
     /**
      * Get location.

--- a/src/Knp/DoctrineBehaviors/Model/Sluggable/Sluggable.php
+++ b/src/Knp/DoctrineBehaviors/Model/Sluggable/Sluggable.php
@@ -18,7 +18,7 @@ trait Sluggable
      *
      * @ORM\Column(type="string")
      */
-    private $slug;
+    protected $slug;
 
     /**
      * Returns an array of the fields used to generate the slug.

--- a/src/Knp/DoctrineBehaviors/Model/Sortable/Sortable.php
+++ b/src/Knp/DoctrineBehaviors/Model/Sortable/Sortable.php
@@ -7,7 +7,7 @@ trait Sortable
     /**
      * @ORM\Column(type="integer")
      */
-    private $sort = 1;
+    protected $sort = 1;
 
     private $reordered = false;
 

--- a/src/Knp/DoctrineBehaviors/Model/Tree/Node.php
+++ b/src/Knp/DoctrineBehaviors/Model/Tree/Node.php
@@ -36,7 +36,7 @@ trait Node
      *
      * @ORM\Column(type="string", length=255)
      */
-    private $materializedPath = '';
+    protected $materializedPath = '';
 
     /**
      * Returns path separator for entity's materialized path.


### PR DESCRIPTION
Given there is a class `EntityImage` which extends `Image`. And `Image` uses the following traits: `Timestampable` + `Sortable`. When generating the database based on `EntityImage` annotations, doctrine will only create the `Timestampable` fields.

Setting the trait properties to `protected` fixes this issue and creates the db fields correctly as doctrine annotation reader now can see all the `EntityImage` properties.

Build passed:
https://travis-ci.org/illarra/DoctrineBehaviors/builds/9986692
