### PR TITLE
[Translatable] Fix property access on twig

### DIFF
--- a/src/Knp/DoctrineBehaviors/Model/Translatable/TranslatableMethods.php
+++ b/src/Knp/DoctrineBehaviors/Model/Translatable/TranslatableMethods.php
@@ -134,6 +134,9 @@ trait TranslatableMethods
 
     protected function proxyCurrentLocaleTranslation($method, array $arguments = [])
     {
+        if (!method_exists(self::getTranslationEntityClass(), $method))
+            $method = 'get'. ucfirst($method);
+
         return call_user_func_array(
             [$this->translate($this->getCurrentLocale()), $method],
             $arguments


### PR DESCRIPTION
This should fix this warning. 

An exception has been thrown during the rendering of a template ("Warning: call_user_func_array() expects parameter 1 to be a valid callback, class 'MyClassTranslation' does not have a method 'name' in ../vendor/knplabs/doctrine-behaviors/src/Knp/DoctrineBehaviors/Model/Translatable/TranslatableMethods.php line 140") in MyBundle:Default:index.html.twig at line 1.

Twig calls 'name' instead 'getName'
