### PR TITLE
Parametrized translatable and translation Traits

### DIFF
--- a/config/orm-services.yml
+++ b/config/orm-services.yml
@@ -3,6 +3,8 @@ parameters:
     knp.doctrine_behaviors.reflection.is_recursive: true
     knp.doctrine_behaviors.translatable_listener.class: Knp\DoctrineBehaviors\ORM\Translatable\TranslatableListener
     knp.doctrine_behaviors.translatable_listener.current_locale_callable.class: Knp\DoctrineBehaviors\ORM\Translatable\CurrentLocaleCallable
+    knp.doctrine_behaviours.translatable_listener.translatable_trait: Knp\DoctrineBehaviors\Model\Translatable\Translatable
+    knp.doctrine_behaviours.translatable_listener.translation_trait: Knp\DoctrineBehaviors\Model\Translatable\Translation
     knp.doctrine_behaviors.softdeletable_listener.class: Knp\DoctrineBehaviors\ORM\SoftDeletable\SoftDeletableListener
     knp.doctrine_behaviors.timestampable_listener.class: Knp\DoctrineBehaviors\ORM\Timestampable\TimestampableListener
     knp.doctrine_behaviors.blameable_listener.class: Knp\DoctrineBehaviors\ORM\Blameable\BlameableListener
@@ -25,6 +27,8 @@ services:
             - "@knp.doctrine_behaviors.reflection.class_analyzer"
             - "%knp.doctrine_behaviors.reflection.is_recursive%"
             - "@knp.doctrine_behaviors.translatable_listener.current_locale_callable"
+            - "%knp.doctrine_behaviours.translatable_listener.translatable_trait%"
+            - "%knp.doctrine_behaviours.translatable_listener.translation_trait%"
         tags:
             - { name: doctrine.event_subscriber }
 

--- a/src/Knp/DoctrineBehaviors/ORM/Translatable/TranslatableListener.php
+++ b/src/Knp/DoctrineBehaviors/ORM/Translatable/TranslatableListener.php
@@ -29,12 +29,17 @@ use Doctrine\Common\EventSubscriber,
 class TranslatableListener extends AbstractListener
 {
     private $currentLocaleCallable;
+    private $translatableTrait;
+    private $translationTrait;
 
-    public function __construct(ClassAnalyzer $classAnalyzer, $isRecursive, callable $currentLocaleCallable = null)
+    public function __construct(ClassAnalyzer $classAnalyzer, $isRecursive, callable $currentLocaleCallable = null,
+                                $translatableTrait, $translationTrait)
     {
         parent::__construct($classAnalyzer, $isRecursive);
-        
+
         $this->currentLocaleCallable = $currentLocaleCallable;
+        $this->translatableTrait = $translatableTrait;
+        $this->translationTrait = $translationTrait;
     }
 
     /**
@@ -122,7 +127,7 @@ class TranslatableListener extends AbstractListener
      */
     private function isTranslatable(ClassMetadata $classMetadata, $isRecursive = false)
     {
-        return $this->getClassAnalyzer()->hasTrait($classMetadata->reflClass, 'Knp\DoctrineBehaviors\Model\Translatable\Translatable', $this->isRecursive);
+        return $this->getClassAnalyzer()->hasTrait($classMetadata->reflClass, $this->translatableTrait, $this->isRecursive);
     }
 
     /**
@@ -131,7 +136,7 @@ class TranslatableListener extends AbstractListener
      */
     private function isTranslation(ClassMetadata $classMetadata)
     {
-        return $this->getClassAnalyzer()->hasTrait($classMetadata->reflClass, 'Knp\DoctrineBehaviors\Model\Translatable\Translation', $this->isRecursive);
+        return $this->getClassAnalyzer()->hasTrait($classMetadata->reflClass, $this->translationTrait, $this->isRecursive);
     }
 
     public function postLoad(LifecycleEventArgs $eventArgs)

--- a/tests/Knp/DoctrineBehaviors/ORM/TranslatableTest.php
+++ b/tests/Knp/DoctrineBehaviors/ORM/TranslatableTest.php
@@ -30,7 +30,9 @@ class TranslatableTest extends \PHPUnit_Framework_TestCase
             function()
             {
                 return 'en';
-            }
+            },
+            'Knp\DoctrineBehaviors\Model\Translatable\Translatable',
+            'Knp\DoctrineBehaviors\Model\Translatable\Translation'
         ));
 
         return $em;


### PR DESCRIPTION
The Traits that the TranslationListener service uses in order to check
if an Entity is a translatable or a translation object can now be
injected and configured.

This is especially useful when you need to extend a Translation/Translatable behavior and need to work with your own traits
