### PR TITLE
ClassAnalyzer::hasTrait returns false if $parentClass is NULL

### DIFF
--- a/src/Knp/DoctrineBehaviors/Reflection/ClassAnalyzer.php
+++ b/src/Knp/DoctrineBehaviors/Reflection/ClassAnalyzer.php
@@ -29,10 +29,10 @@ class ClassAnalyzer
 
         $parentClass = $class->getParentClass();
 
-        if ((false === $isRecursive) || (false === $parentClass)) {
+        if ((false === $isRecursive) || (false === $parentClass) || (null === $parentClass)) {
             return false;
         }
-        
+
         return $this->hasTrait($parentClass, $traitName, $isRecursive);
     }
 


### PR DESCRIPTION
This throws class type error otherwise. I have my own BaseEntity class and ->getParentClass() returns null, so this collapses.
