### PR TITLE
Fix/bc layer

### DIFF
--- a/src/ORM/Blameable/BlameableListener.php
+++ b/src/ORM/Blameable/BlameableListener.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * This file is part of the KnpDoctrineBehaviors package.
+ *
+ * (c) KnpLabs <http://knplabs.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Knp\DoctrineBehaviors\ORM\Blameable;
+
+/**
+ * @deprecated
+ */
+final class BlameableListener extends BlameableSubscriber
+{
+    public function __construct()
+    {
+        trigger_error('use BlameableSubscriber instead.', E_USER_DEPRECATED);
+        call_user_func_array(array('parent', '__construct'), func_get_args());
+    }
+}

--- a/src/ORM/Geocodable/GeocodableListener.php
+++ b/src/ORM/Geocodable/GeocodableListener.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * This file is part of the KnpDoctrineBehaviors package.
+ *
+ * (c) KnpLabs <http://knplabs.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Knp\DoctrineBehaviors\ORM\Geocodable;
+
+/**
+ * @deprecated
+ */
+final class GeocodableListener extends GeocodableSubscriber
+{
+    public function __construct()
+    {
+        trigger_error('use GeocodableSubscriber instead.', E_USER_DEPRECATED);
+        call_user_func_array(array('parent', '__construct'), func_get_args());
+    }
+}

--- a/src/ORM/Loggable/LoggableListener.php
+++ b/src/ORM/Loggable/LoggableListener.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * This file is part of the KnpDoctrineBehaviors package.
+ *
+ * (c) KnpLabs <http://knplabs.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Knp\DoctrineBehaviors\ORM\Loggable;
+
+/**
+ * @deprecated
+ */
+final class LoggableListener extends LoggableSubscriber
+{
+    public function __construct()
+    {
+        trigger_error('use LoggableSubscriber instead.', E_USER_DEPRECATED);
+        call_user_func_array(array('parent', '__construct'), func_get_args());
+    }
+}

--- a/src/ORM/Sluggable/SluggableListener.php
+++ b/src/ORM/Sluggable/SluggableListener.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * This file is part of the KnpDoctrineBehaviors package.
+ *
+ * (c) KnpLabs <http://knplabs.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Knp\DoctrineBehaviors\ORM\Sluggable;
+
+/**
+ * @deprecated
+ */
+final class SluggableListener extends SluggableSubscriber
+{
+    public function __construct()
+    {
+        trigger_error('use SluggableSubscriber instead.', E_USER_DEPRECATED);
+        call_user_func_array(array('parent', '__construct'), func_get_args());
+    }
+}

--- a/src/ORM/SoftDeletable/SoftDeletableListener.php
+++ b/src/ORM/SoftDeletable/SoftDeletableListener.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * This file is part of the KnpDoctrineBehaviors package.
+ *
+ * (c) KnpLabs <http://knplabs.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Knp\DoctrineBehaviors\ORM\SoftDeletable;
+
+/**
+ * @deprecated
+ */
+final class SoftDeletableListener extends SoftDeletableSubscriber
+{
+    public function __construct()
+    {
+        trigger_error('use SoftDeletableSubscriber instead.', E_USER_DEPRECATED);
+        call_user_func_array(array('parent', '__construct'), func_get_args());
+    }
+}

--- a/src/ORM/Timestampable/TimestampableListener.php
+++ b/src/ORM/Timestampable/TimestampableListener.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * This file is part of the KnpDoctrineBehaviors package.
+ *
+ * (c) KnpLabs <http://knplabs.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Knp\DoctrineBehaviors\ORM\Timestampable;
+
+/**
+ * @deprecated
+ */
+final class TimestampableListener extends TimestampableSubscriber
+{
+    public function __construct()
+    {
+        trigger_error('use TimestampableSubscriber instead.', E_USER_DEPRECATED);
+        call_user_func_array(array('parent', '__construct'), func_get_args());
+    }
+}

--- a/src/ORM/Translatable/TranslatableListener.php
+++ b/src/ORM/Translatable/TranslatableListener.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * This file is part of the KnpDoctrineBehaviors package.
+ *
+ * (c) KnpLabs <http://knplabs.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Knp\DoctrineBehaviors\ORM\Translatable;
+
+/**
+ * @deprecated
+ */
+final class TranslatableListener extends TranslatableSubscriber
+{
+    public function __construct()
+    {
+        trigger_error('use TranslatableSubscriber instead.', E_USER_DEPRECATED);
+        call_user_func_array(array('parent', '__construct'), func_get_args());
+    }
+}

--- a/tests/Knp/DoctrineBehaviors/ORM/BlameableTest.php
+++ b/tests/Knp/DoctrineBehaviors/ORM/BlameableTest.php
@@ -190,4 +190,19 @@ class BlameableTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($entity->getCreatedBy(), 'createdBy is a not updated because not a user entity object');
         $this->assertNull($entity->getUpdatedBy(), 'updatedBy is a not updated because not a user entity object');
     }
+
+    /**
+     * @test
+     * @expectedException Exception
+     */
+    public function should_notice_deprecation()
+    {
+        set_error_handler(function() {throw new \Exception; }, E_USER_DEPRECATED);
+        new \Knp\DoctrineBehaviors\ORM\Blameable\BlameableListener;
+    }
+
+    public function tearDown()
+    {
+        restore_error_handler();
+    }
 }

--- a/tests/Knp/DoctrineBehaviors/ORM/GeocodableTest.php
+++ b/tests/Knp/DoctrineBehaviors/ORM/GeocodableTest.php
@@ -110,4 +110,19 @@ class GeocodableTest extends \PHPUnit_Framework_TestCase
         $cities = $repo->findByDistance(new Point(47.896319, 7.352943), 6223000);
         $this->assertCount(3, $cities, 'Paris, Nantes and New-York are less than 6223 km far from Reguisheim');
     }
+
+    /**
+     * @test
+     * @expectedException Exception
+     */
+    public function should_notice_deprecation()
+    {
+        set_error_handler(function() {throw new \Exception; }, E_USER_DEPRECATED);
+        new \Knp\DoctrineBehaviors\ORM\Geocodable\GeocodableListener;
+    }
+
+    public function tearDown()
+    {
+        restore_error_handler();
+    }
 }

--- a/tests/Knp/DoctrineBehaviors/ORM/LoggableTest.php
+++ b/tests/Knp/DoctrineBehaviors/ORM/LoggableTest.php
@@ -124,4 +124,19 @@ class LoggableTest extends \PHPUnit_Framework_TestCase
             'BehaviorFixtures\ORM\LoggableEntity #1 removed'
         );
     }
+
+    /**
+     * @test
+     * @expectedException Exception
+     */
+    public function should_notice_deprecation()
+    {
+        set_error_handler(function() {throw new \Exception; }, E_USER_DEPRECATED);
+        new \Knp\DoctrineBehaviors\ORM\Loggable\LoggableListener;
+    }
+
+    public function tearDown()
+    {
+        restore_error_handler();
+    }
 }

--- a/tests/Knp/DoctrineBehaviors/ORM/SluggableTest.php
+++ b/tests/Knp/DoctrineBehaviors/ORM/SluggableTest.php
@@ -100,4 +100,19 @@ class SluggableTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($entity->getSlug(), $expected);
     }
+
+    /**
+     * @test
+     * @expectedException Exception
+     */
+    public function should_notice_deprecation()
+    {
+        set_error_handler(function() {throw new \Exception; }, E_USER_DEPRECATED);
+        new \Knp\DoctrineBehaviors\ORM\Sluggable\SluggableListener;
+    }
+
+    public function tearDown()
+    {
+        restore_error_handler();
+    }
 }

--- a/tests/Knp/DoctrineBehaviors/ORM/SoftDeletableTest.php
+++ b/tests/Knp/DoctrineBehaviors/ORM/SoftDeletableTest.php
@@ -103,4 +103,19 @@ class SoftDeletableTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($entity->isDeleted());
     }
+
+    /**
+     * @test
+     * @expectedException Exception
+     */
+    public function should_notice_deprecation()
+    {
+        set_error_handler(function() {throw new \Exception; }, E_USER_DEPRECATED);
+        new \Knp\DoctrineBehaviors\ORM\SoftDeletable\SoftDeletableListener;
+    }
+
+    public function tearDown()
+    {
+        restore_error_handler();
+    }
 }

--- a/tests/Knp/DoctrineBehaviors/ORM/TimestampableTest.php
+++ b/tests/Knp/DoctrineBehaviors/ORM/TimestampableTest.php
@@ -161,4 +161,19 @@ class TimestampableTest extends \PHPUnit_Framework_TestCase
             'Update timestamp has changed'
         );
     }
+
+    /**
+     * @test
+     * @expectedException Exception
+     */
+    public function should_notice_deprecation()
+    {
+        set_error_handler(function() {throw new \Exception; }, E_USER_DEPRECATED);
+        new \Knp\DoctrineBehaviors\ORM\Timestampable\TimestampableListener;
+    }
+
+    public function tearDown()
+    {
+        restore_error_handler();
+    }
 }

--- a/tests/Knp/DoctrineBehaviors/ORM/TranslatableTest.php
+++ b/tests/Knp/DoctrineBehaviors/ORM/TranslatableTest.php
@@ -180,4 +180,19 @@ class TranslatableTest extends \PHPUnit_Framework_TestCase
         $em->refresh($entity);
         $this->assertNotEquals('Hallo', $entity->translate('nl')->getTitle());
     }
+
+    /**
+     * @test
+     * @expectedException Exception
+     */
+    public function should_notice_deprecation()
+    {
+        set_error_handler(function() {throw new \Exception; }, E_USER_DEPRECATED);
+        new \Knp\DoctrineBehaviors\ORM\Translatable\TranslatableListener;
+    }
+
+    public function tearDown()
+    {
+        restore_error_handler();
+    }
 }


### PR DESCRIPTION
It will trigger errors of type `E_USER_DEPRECATED`. You will have to configure your error handler to bypass them if you wish to still use the old classes.
