### PR TITLE
[Translatable] Restore BC-break in Translation Traits

### DIFF
--- a/src/Model/Translatable/TranslationMethods.php
+++ b/src/Model/Translatable/TranslationMethods.php
@@ -20,6 +20,14 @@ trait TranslationMethods
 {
 
     /**
+     * Restored to resolve BC-break in #75e1187
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
      * Sets entity, that this translation should be mapped to.
      *
      * @param Translatable $translatable The translatable

--- a/src/Model/Translatable/TranslationProperties.php
+++ b/src/Model/Translatable/TranslationProperties.php
@@ -18,6 +18,10 @@ namespace Knp\DoctrineBehaviors\Model\Translatable;
  */
 trait TranslationProperties
 {
+    /**
+     * Restored to resolve BC-break in #75e1187
+     */
+    protected $id;
 
     protected $locale;
 

--- a/tests/fixtures/BehaviorFixtures/ORM/TranslatableEntityTranslation.php
+++ b/tests/fixtures/BehaviorFixtures/ORM/TranslatableEntityTranslation.php
@@ -12,18 +12,6 @@ class TranslatableEntityTranslation
 {
     use Model\Translatable\Translation;
 
-    protected $id;
-
-    /**
-     * Returns translation ID.
-     *
-     * @return integer The ID.
-     */
-    public function getId()
-    {
-        return $this->id;
-    }
-
     /**
      * @ORM\Column(type="string")
      */


### PR DESCRIPTION
I think this should be enough to restore the BC-break introduced in
75e1187fbf4a116901491c5d31165b8824d589eb.
