### PR TITLE
Try to use getters when getting non-existent field values for Sluggable

### DIFF
--- a/src/Model/Sluggable/SluggableMethods.php
+++ b/src/Model/Sluggable/SluggableMethods.php
@@ -74,9 +74,17 @@ trait SluggableMethods
             $usableValues = [];
 
             foreach ($fields as $field) {
-                // Too bad empty is a language construct...otherwise we could use the return value in a write context :)
-                $methodName = 'get' . ucfirst($field);
-                $val = $this->{$methodName}();
+                if (property_exists($this, $field)) {
+                    $val = $this->{$field};
+                } else {
+                    $methodName = 'get' . ucfirst($field);
+                    if (method_exists($this, $methodName)) {
+                        $val = $this->{$methodName}();
+                    } else {
+                        $val = null;
+                    }
+                }
+
                 if ( !empty( $val ) ) {
                     $usableValues[] = $val;
                 }

--- a/src/Model/Sluggable/SluggableMethods.php
+++ b/src/Model/Sluggable/SluggableMethods.php
@@ -75,7 +75,8 @@ trait SluggableMethods
 
             foreach ($fields as $field) {
                 // Too bad empty is a language construct...otherwise we could use the return value in a write context :)
-                $val = $this->{$field};
+                $methodName = 'get' . ucfirst($field);
+                $val = $this->{$methodName}();
                 if ( !empty( $val ) ) {
                     $usableValues[] = $val;
                 }

--- a/tests/Knp/DoctrineBehaviors/ORM/SluggableMultiTest.php
+++ b/tests/Knp/DoctrineBehaviors/ORM/SluggableMultiTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Tests\Knp\DoctrineBehaviors\ORM;
+
+use Knp\DoctrineBehaviors\Reflection\ClassAnalyzer;
+use Doctrine\Common\EventManager;
+
+require_once 'EntityManagerProvider.php';
+
+class SluggableMultiTest extends \PHPUnit_Framework_TestCase
+{
+    use EntityManagerProvider;
+
+    protected function getUsedEntityFixtures()
+    {
+        return array(
+            'BehaviorFixtures\\ORM\\SluggableMultiEntity'
+        );
+    }
+
+    protected function getEventManager()
+    {
+        $em = new EventManager;
+
+        $em->addEventSubscriber(
+            new \Knp\DoctrineBehaviors\ORM\Sluggable\SluggableSubscriber(
+                new ClassAnalyzer(),
+                false,
+                'Knp\DoctrineBehaviors\Model\Sluggable\Sluggable'
+        ));
+
+        return $em;
+    }
+
+    public function testSlugLoading()
+    {
+        $em = $this->getEntityManager();
+
+        $entity = new \BehaviorFixtures\ORM\SluggableMultiEntity();
+
+        $expected = 'the-name-title';
+
+        $entity->setName('The name');
+
+        $em->persist($entity);
+        $em->flush();
+
+        $this->assertNotNull($id = $entity->getId());
+
+        $em->clear();
+
+        $entity = $em->getRepository('BehaviorFixtures\ORM\SluggableMultiEntity')->find($id);
+
+        $this->assertNotNull($entity);
+        $this->assertEquals($entity->getSlug(), $expected);
+    }
+
+    public function testNotUpdatedSlug()
+    {
+        $em = $this->getEntityManager();
+
+        $entity = new \BehaviorFixtures\ORM\SluggableMultiEntity();
+
+        $expected = 'the-name-title';
+
+        $entity->setName('The name');
+
+        $em->persist($entity);
+        $em->flush();
+
+        $entity->setDate(new \DateTime);
+
+        $em->persist($entity);
+        $em->flush();
+
+        $this->assertEquals($entity->getSlug(), $expected);
+    }
+
+    public function testUpdatedSlug()
+    {
+        $em = $this->getEntityManager();
+
+        $entity = new \BehaviorFixtures\ORM\SluggableMultiEntity();
+
+        $expected = 'the-name-title';
+
+        $entity->setName('The name');
+
+        $em->persist($entity);
+        $em->flush();
+
+        $this->assertEquals($entity->getSlug(), $expected);
+
+        $expected = 'the-name-2-title';
+
+        $entity->setName('The name 2');
+
+        $em->persist($entity);
+        $em->flush();
+
+        $this->assertEquals($entity->getSlug(), $expected);
+    }
+}

--- a/tests/fixtures/BehaviorFixtures/ORM/SluggableMultiEntity.php
+++ b/tests/fixtures/BehaviorFixtures/ORM/SluggableMultiEntity.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace BehaviorFixtures\ORM;
+
+use Doctrine\ORM\Mapping as ORM;
+use Knp\DoctrineBehaviors\Model;
+
+/**
+ * @ORM\Entity
+ */
+class SluggableMultiEntity
+{
+    use Model\Sluggable\Sluggable;
+
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(type="string")
+     */
+    protected $name;
+
+    /**
+     * @ORM\Column(type="datetime")
+     */
+    protected $date;
+
+    public function __construct()
+    {
+        $this->date = (new \DateTime)->modify('-1 year');
+    }
+
+    /**
+     * Returns object id.
+     *
+     * @return integer
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getDate()
+    {
+        return $this->date;
+    }
+
+    public function setDate($date)
+    {
+        $this->date = $date;
+
+        return $this;
+    }
+
+    protected function getSluggableFields()
+    {
+        return [ 'name', 'title' ];
+    }
+
+    public function getTitle()
+    {
+        return 'title';
+    }
+}


### PR DESCRIPTION
Use getters when getting field values for Sluggable, if property does not exist (solves problem with accessing non-existent field, like in translations)