### PR TITLE
[Translatable] Link Translatable to Translation via annotation

### DIFF
--- a/config/orm-services.yml
+++ b/config/orm-services.yml
@@ -42,6 +42,7 @@ services:
             - "%knp.doctrine_behaviors.translatable_subscriber.translation_trait%"
             - "%knp.doctrine_behaviors.translatable_subscriber.translatable_fetch_method%"
             - "%knp.doctrine_behaviors.translatable_subscriber.translation_fetch_method%"
+            - "@annotation_reader"
         tags:
             - { name: doctrine.event_subscriber }
 

--- a/src/Annotations/TranslateReference.php
+++ b/src/Annotations/TranslateReference.php
@@ -9,12 +9,13 @@
  * file that was distributed with this source code.
  */
 
-namespace Knp\DoctrineBehaviours\Annotations;
-
+namespace Knp\DoctrineBehaviors\Annotations;
 /**
- * TranslationReference annotation
+ * TranslateReference annotation
  * @Annotation
+ * @Target("CLASS")
  */
-class TranslationReference {
-    public $className;
-} 
+class TranslateReference {
+    public $translatableClass;
+    public $translationClass;
+}

--- a/src/Annotations/TranslationReference.php
+++ b/src/Annotations/TranslationReference.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the KnpDoctrineBehaviors package.
+ *
+ * (c) KnpLabs <http://knplabs.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Knp\DoctrineBehaviours\Annotations;
+
+/**
+ * TranslationReference annotation
+ * @Annotation
+ */
+class TranslationReference {
+    public $className;
+} 

--- a/src/Model/Translatable/TranslatableMethods.php
+++ b/src/Model/Translatable/TranslatableMethods.php
@@ -156,9 +156,9 @@ trait TranslatableMethods
     {
         $reflectionClass = new \ReflectionClass(__CLASS__);
         $reader = new CachedReader(new AnnotationReader(), new ArrayCache());
-        $translationReference = $reader->getClassAnnotations($reflectionClass, 'Knp\DoctrineBehaviours\Annotations\TranslationReference');
+        $translationReference = $reader->getClassAnnotation($reflectionClass, 'Knp\DoctrineBehaviors\Annotations\TranslateReference');
         if ($translationReference) {
-            return $translationReference->className;
+            return $translationReference->translationClass;
         }
         else {
             return __CLASS__.'Translation';

--- a/src/Model/Translatable/TranslatableMethods.php
+++ b/src/Model/Translatable/TranslatableMethods.php
@@ -12,6 +12,9 @@
 namespace Knp\DoctrineBehaviors\Model\Translatable;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\CachedReader;
+use Doctrine\Common\Cache\ArrayCache;
 
 /**
  * Translatable trait.
@@ -151,7 +154,15 @@ trait TranslatableMethods
      */
     public static function getTranslationEntityClass()
     {
-        return __CLASS__.'Translation';
+        $reflectionClass = new \ReflectionClass(__CLASS__);
+        $reader = new CachedReader(new AnnotationReader(), new ArrayCache());
+        $translationReference = $reader->getClassAnnotations($reflectionClass, 'Knp\DoctrineBehaviours\Annotations\TranslationReference');
+        if ($translationReference) {
+            return $translationReference->className;
+        }
+        else {
+            return __CLASS__.'Translation';
+        }
     }
 
     /**

--- a/src/ORM/Translatable/TranslatableSubscriber.php
+++ b/src/ORM/Translatable/TranslatableSubscriber.php
@@ -212,6 +212,8 @@ class TranslatableSubscriber extends AbstractSubscriber
     private function mapTranslation(ClassMetadata $classMetadata)
     {
         if (!$classMetadata->hasAssociation('translatable')) {
+            $translationReference = $this->annotationReader->getClassAnnotation($classMetadata->reflClass, 'Knp\DoctrineBehaviors\Annotations\TranslateReference');
+            $targetEntity = $translationReference ? $translationReference->translatableClass : substr($classMetadata->name, 0, -11);
             $classMetadata->mapManyToOne([
                 'fieldName'    => 'translatable',
                 'inversedBy'   => 'translations',
@@ -221,7 +223,7 @@ class TranslatableSubscriber extends AbstractSubscriber
                     'referencedColumnName' => 'id',
                     'onDelete'             => 'CASCADE'
                 ]],
-                'targetEntity' => substr($classMetadata->name, 0, -11)
+                'targetEntity' => $targetEntity
             ]);
         }
 

--- a/src/ORM/Translatable/TranslatableSubscriber.php
+++ b/src/ORM/Translatable/TranslatableSubscriber.php
@@ -200,13 +200,15 @@ class TranslatableSubscriber extends AbstractSubscriber
     private function mapTranslatable(ClassMetadata $classMetadata)
     {
         if (!$classMetadata->hasAssociation('translations')) {
+            $translationReference = $this->annotationReader->getClassAnnotation($classMetadata->reflClass, 'Knp\DoctrineBehaviors\Annotations\TranslateReference');
+            $targetEntity = $translationReference ? $translationReference->translationClass : $classMetadata->name.'Translation';
             $classMetadata->mapOneToMany([
                 'fieldName'     => 'translations',
                 'mappedBy'      => 'translatable',
                 'indexBy'       => 'locale',
                 'cascade'       => ['persist', 'merge', 'remove'],
                 'fetch'         => $this->translatableFetchMode,
-                'targetEntity'  => $classMetadata->name.'Translation',
+                'targetEntity'  => $targetEntity,
                 'orphanRemoval' => true
             ]);
         }

--- a/src/ORM/Translatable/TranslatableSubscriber.php
+++ b/src/ORM/Translatable/TranslatableSubscriber.php
@@ -52,6 +52,7 @@ class TranslatableSubscriber extends AbstractSubscriber
         $this->translationTrait = $translationTrait;
         $this->translatableFetchMode = $this->convertFetchString($translatableFetchMode);
         $this->translationFetchMode = $this->convertFetchString($translationFetchMode);
+        $this->annotationReader = $annotationReader;
     }
 
     /**

--- a/src/ORM/Translatable/TranslatableSubscriber.php
+++ b/src/ORM/Translatable/TranslatableSubscriber.php
@@ -26,7 +26,7 @@ use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Events;
 use Doctrine\DBAL\Platforms;
-use Doctrine\Common\Annotations;
+use Doctrine\Common\Annotations\Reader;
 
 /**
  * Translatable Doctrine2 subscriber.

--- a/src/ORM/Translatable/TranslatableSubscriber.php
+++ b/src/ORM/Translatable/TranslatableSubscriber.php
@@ -26,6 +26,7 @@ use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Events;
 use Doctrine\DBAL\Platforms;
+use Doctrine\Common\Annotations;
 
 /**
  * Translatable Doctrine2 subscriber.
@@ -39,9 +40,10 @@ class TranslatableSubscriber extends AbstractSubscriber
     private $translationTrait;
     private $translatableFetchMode;
     private $translationFetchMode;
+    private $annotationReader;
 
     public function __construct(ClassAnalyzer $classAnalyzer, $isRecursive, callable $currentLocaleCallable = null,
-                                $translatableTrait, $translationTrait, $translatableFetchMode, $translationFetchMode)
+                                $translatableTrait, $translationTrait, $translatableFetchMode, $translationFetchMode, Reader $annotationReader)
     {
         parent::__construct($classAnalyzer, $isRecursive);
 

--- a/tests/Knp/DoctrineBehaviors/ORM/TranslatableTest.php
+++ b/tests/Knp/DoctrineBehaviors/ORM/TranslatableTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Knp\DoctrineBehaviors\ORM;
 
+use Doctrine\Common\Annotations\AnnotationReader;
 use Knp\DoctrineBehaviors\Reflection\ClassAnalyzer;
 use Doctrine\Common\EventManager;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
@@ -23,7 +24,6 @@ class TranslatableTest extends \PHPUnit_Framework_TestCase
     protected function getEventManager()
     {
         $em = new EventManager;
-
         $em->addEventSubscriber(new \Knp\DoctrineBehaviors\ORM\Translatable\TranslatableSubscriber(
             new ClassAnalyzer(),
             false,
@@ -34,7 +34,8 @@ class TranslatableTest extends \PHPUnit_Framework_TestCase
             'Knp\DoctrineBehaviors\Model\Translatable\Translatable',
             'Knp\DoctrineBehaviors\Model\Translatable\Translation',
             'LAZY',
-            'LAZY'
+            'LAZY',
+            new AnnotationReader()
         ));
 
         return $em;


### PR DESCRIPTION
Usage:
Add annotation to translatable class

``` php
/**
 * @ORM\Entity
 * @TranslateReference(translationClass="YourBundle\Path\To\SomeTranslation");
 */
class Some {
    use ORMBehaviors\Translatable\Translatable;
```

And to translation class

``` php
/**
 * @ORM\Entity
 * @TranslateReference(translatableClass="YourBundle\Path\To\Some");
 */
class SomeTranslation {
    use ORMBehaviors\Translatable\Translation;
```
- more flexibility in naming
