### PR TITLE
Allow locale as an association entity

### DIFF
--- a/src/Model/Translatable/TranslatableMethods.php
+++ b/src/Model/Translatable/TranslatableMethods.php
@@ -49,7 +49,7 @@ trait TranslatableMethods
      */
     public function addTranslation($translation)
     {
-        $this->getTranslations()->set($translation->getLocale(), $translation);
+        $this->getTranslations()->set((string)$translation->getLocale(), $translation);
         $translation->setTranslatable($this);
 
         return $this;
@@ -99,7 +99,7 @@ trait TranslatableMethods
         $translation = new $class();
         $translation->setLocale($locale);
 
-        $this->getNewTranslations()->set($translation->getLocale(), $translation);
+        $this->getNewTranslations()->set((string)$translation->getLocale(), $translation);
         $translation->setTranslatable($this);
 
         return $translation;

--- a/src/ORM/Translatable/TranslatableSubscriber.php
+++ b/src/ORM/Translatable/TranslatableSubscriber.php
@@ -232,7 +232,7 @@ class TranslatableSubscriber extends AbstractSubscriber
             ];
         }
 
-        if (!$classMetadata->hasField('locale')) {
+        if (!($classMetadata->hasField('locale') || $classMetadata->hasAssociation('locale'))) {
             $classMetadata->mapField(array(
                 'fieldName' => 'locale',
                 'type'      => 'string'


### PR DESCRIPTION
This allows to have ManyToOne association as location

```
/**
 * @var \Acme\Locale $locale
 *
 * @ORM\ManyToOne(targetEntity="Locale")
 * @ORM\JoinColumn(name="locale", referencedColumnName="id", nullable=false)
 */
protected $locale;
```