### PR TITLE
Issue #172: ability to choose the class translation name

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,11 @@ You now have a working `Category` that behaves like:
 ### translatable:
 
 If you're working on a `Category` entity, the `Translatable` behavior expects a
-**CategoryTranslation** entity.  This naming convention avoids you to handle manually entity associations.
+**CategoryTranslation** entity by default. If you prefer to use a different class name for the translation entity,
+you should override the trait method `getTranslationEntityClass` in the translatable entity and `getTranslatableEntityClass`
+in the translation entity. If you override one, you also need to override the other to return the inverse class.
+
+The default naming convention (or its customization via trait methods) avoids you to handle manually entity associations.
 It is handled automatically by the TranslationSubscriber.
 
 In order to use the Translatable trait, you will have to create this `CategoryTranslation` entity.

--- a/src/Model/Translatable/TranslationMethods.php
+++ b/src/Model/Translatable/TranslationMethods.php
@@ -19,6 +19,17 @@ namespace Knp\DoctrineBehaviors\Model\Translatable;
 trait TranslationMethods
 {
     /**
+     * Returns the translatable entity class name.
+     *
+     * @return string
+     */
+    public static function getTranslatableEntityClass()
+    {
+        // By default, the translatable class has the same name but without the "Translation" suffix
+        return substr(__CLASS__, 0, -11);
+    }
+
+    /**
      * Returns object id.
      *
      * @return mixed

--- a/src/ORM/Translatable/TranslatableSubscriber.php
+++ b/src/ORM/Translatable/TranslatableSubscriber.php
@@ -203,7 +203,7 @@ class TranslatableSubscriber extends AbstractSubscriber
                 'indexBy'       => 'locale',
                 'cascade'       => ['persist', 'merge', 'remove'],
                 'fetch'         => $this->translatableFetchMode,
-                'targetEntity'  => $classMetadata->name.'Translation',
+                'targetEntity'  => $classMetadata->getReflectionClass()->getMethod('getTranslationEntityClass')->invoke(null),
                 'orphanRemoval' => true
             ]);
         }
@@ -221,7 +221,7 @@ class TranslatableSubscriber extends AbstractSubscriber
                     'referencedColumnName' => 'id',
                     'onDelete'             => 'CASCADE'
                 ]],
-                'targetEntity' => substr($classMetadata->name, 0, -11)
+                'targetEntity' => $classMetadata->getReflectionClass()->getMethod('getTranslatableEntityClass')->invoke(null),
             ]);
         }
 

--- a/tests/Knp/DoctrineBehaviors/ORM/TranslatableTest.php
+++ b/tests/Knp/DoctrineBehaviors/ORM/TranslatableTest.php
@@ -180,26 +180,22 @@ class TranslatableTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function should_have_ontToMany_relation()
+    public function should_have_oneToMany_relation()
     {
-        $em = $this->getEntityManager();
-
-        $meta = $em->getClassMetadata('BehaviorFixtures\ORM\TranslatableEntityTranslation');
-        $this->assertEquals(
+        $this->assertTranslationsOneToManyMapped(
             'BehaviorFixtures\ORM\TranslatableEntity',
-            $meta->getAssociationTargetClass('translatable')
+            'BehaviorFixtures\ORM\TranslatableEntityTranslation'
         );
+    }
 
-        $meta = $em->getClassMetadata('BehaviorFixtures\ORM\TranslatableEntity');
-        $this->assertEquals(
-            'BehaviorFixtures\ORM\TranslatableEntityTranslation',
-            $meta->getAssociationTargetClass('translations')
-        );
-        $this->assertTrue($meta->isAssociationInverseSide('translations'));
-
-        $this->assertEquals(
-            ClassMetadataInfo::ONE_TO_MANY,
-            $meta->getAssociationMapping('translations')['type']
+    /**
+     * @test
+     */
+    public function should_have_oneToMany_relation_when_translation_class_name_is_custom()
+    {
+        $this->assertTranslationsOneToManyMapped(
+            'BehaviorFixtures\ORM\TranslatableCustomizedEntity',
+            'BehaviorFixtures\ORM\Translation\TranslatableCustomizedEntityTranslation'
         );
     }
 
@@ -240,5 +236,29 @@ class TranslatableTest extends \PHPUnit_Framework_TestCase
 
         $em->refresh($entity);
         $this->assertNotEquals('Hallo', $entity->translate('nl')->getTitle());
+    }
+
+    /**
+     * Asserts that the one to many relationship between translatable and translations is mapped correctly.
+     *
+     * @param string $translatableClass The class name of the translatable entity
+     * @param string $translationClass  The class name of the translation entity
+     */
+    private function assertTranslationsOneToManyMapped($translatableClass, $translationClass)
+    {
+        $em = $this->getEntityManager();
+
+        $meta = $em->getClassMetadata($translationClass);
+        $this->assertEquals($translatableClass, $meta->getAssociationTargetClass('translatable'));
+
+        $meta = $em->getClassMetadata($translatableClass);
+        $this->assertEquals($translationClass, $meta->getAssociationTargetClass('translations'));
+
+        $this->assertTrue($meta->isAssociationInverseSide('translations'));
+
+        $this->assertEquals(
+            ClassMetadataInfo::ONE_TO_MANY,
+            $meta->getAssociationMapping('translations')['type']
+        );
     }
 }

--- a/tests/fixtures/BehaviorFixtures/ORM/TranslatableCustomizedEntity.php
+++ b/tests/fixtures/BehaviorFixtures/ORM/TranslatableCustomizedEntity.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace BehaviorFixtures\ORM;
+
+use Doctrine\ORM\Mapping as ORM;
+use Knp\DoctrineBehaviors\Model;
+
+/**
+ * @ORM\Entity
+ * Used to test translation classes which declare custom translatable classes.
+ */
+class TranslatableCustomizedEntity
+{
+    use Model\Translatable\Translatable;
+
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getTranslationEntityClass()
+    {
+        return '\BehaviorFixtures\ORM\Translation\TranslatableCustomizedEntityTranslation';
+    }
+
+    public function __call($method, $arguments)
+    {
+        return $this->proxyCurrentLocaleTranslation($method, $arguments);
+    }
+
+    /**
+     * Returns object id.
+     *
+     * @return integer
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+}

--- a/tests/fixtures/BehaviorFixtures/ORM/Translation/TranslatableCustomizedEntityTranslation.php
+++ b/tests/fixtures/BehaviorFixtures/ORM/Translation/TranslatableCustomizedEntityTranslation.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace BehaviorFixtures\ORM\Translation;
+
+use Doctrine\ORM\Mapping as ORM;
+use Knp\DoctrineBehaviors\Model;
+
+/**
+ * @ORM\Entity
+ * Used to test translatable classes which declare a custom translation class.
+ */
+class TranslatableCustomizedEntityTranslation
+{
+    use Model\Translatable\Translation;
+
+    /**
+     * @ORM\Column(type="string")
+     */
+    private $title;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getTranslatableEntityClass()
+    {
+        return '\BehaviorFixtures\ORM\TranslatableCustomizedEntity';
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+}


### PR DESCRIPTION
- As discussed, I enforced the use of the trait methods in the translatable listener
- I created the inverse method to retrieve the in the translation entity
- I created 2 more fixture entities (I'm not 100% happy with their naming but I couldn't come up with a better one). I put the translation into a nested namespace to "break" the default rule of the "Translation" suffix.
- I added a test for verifying the oneToMany relationship also for the "customized" case. Since the 2 tests were equal, I factored its logic into a private assertion method in the test case class which now takes as parameters the 2 classes to verify the association for.
- I updated the relevant section in the readme

Hope this is ok, let me know if I need to change anything :)