### PR TITLE
[Translatable] Compatible with class property and method

### DIFF
--- a/src/Model/Translatable/TranslatableMethods.php
+++ b/src/Model/Translatable/TranslatableMethods.php
@@ -138,6 +138,8 @@ trait TranslatableMethods
 
     protected function proxyCurrentLocaleTranslation($method, array $arguments = [])
     {
+        $method = ('get' === substr($method, 0, 3)) ? $method : 'get'. ucfirst($method);
+
         return call_user_func_array(
             [$this->translate($this->getCurrentLocale()), $method],
             $arguments


### PR DESCRIPTION
In some cases like twig call like {{ post.title }} doen´t work cause first search is property, if we force to getter method always works.
