### PR TITLE
Use symfony property access component to get sluggable fields values

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,9 @@
         }
     ],
     "require": {
-        "php":              ">=5.4",
-        "doctrine/common":  ">=2.2"
+        "php":                     ">=5.4",
+        "doctrine/common":         ">=2.2",
+        "symfony/property-access": ">=2.3"
     },
     "require-dev": {
         "ext-pdo_sqlite":                   "*",

--- a/src/Model/Sluggable/SluggableMethods.php
+++ b/src/Model/Sluggable/SluggableMethods.php
@@ -5,6 +5,7 @@
  */
 
 namespace Knp\DoctrineBehaviors\Model\Sluggable;
+use Symfony\Component\PropertyAccess\PropertyAccess;
 
 /**
  * Sluggable trait.
@@ -73,17 +74,10 @@ trait SluggableMethods
             $fields = $this->getSluggableFields();
             $usableValues = [];
 
+            $accessor = PropertyAccess::createPropertyAccessor();
+
             foreach ($fields as $field) {
-                if (property_exists($this, $field)) {
-                    $val = $this->{$field};
-                } else {
-                    $methodName = 'get' . ucfirst($field);
-                    if (method_exists($this, $methodName)) {
-                        $val = $this->{$methodName}();
-                    } else {
-                        $val = null;
-                    }
-                }
+                $val = $accessor->getValue($this, $field);
 
                 if ( !empty( $val ) ) {
                     $usableValues[] = $val;


### PR DESCRIPTION
This PR replaces the custom property/method access with the [symfony/property-access component](http://symfony.com/doc/current/components/property_access/introduction.html) which is much more powerful. Ex : 

```
public function getSluggableFields()
{
    return ['category.name', 'title'];
}
```
