### PR TITLE
added customizable tree identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ You now have a working `Category` that behaves like:
 
 ```
 
+> it is possible to use another identifier than `id`, simply override `getTreeNodeField` and return your custom identifier (works great in combination with `Sluggable`)
+
 <a name="translatable" id="translatable"></a>
 ### translatable:
 
@@ -487,13 +489,13 @@ class BlogPost
      * @ORM\Column(type="string")
      */
     protected $title;
-    
+
     public function getSluggableFields()
     {
         return [ 'title' ];
     }
-    
-    public function generateSlugValue($values) 
+
+    public function generateSlugValue($values)
     {
         return implode('-', $values);
     }

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ You now have a working `Category` that behaves like:
 
 ```
 
-> it is possible to use another identifier than `id`, simply override `getTreeNodeField` and return your custom identifier (works great in combination with `Sluggable`)
+> it is possible to use another identifier than `id`, simply override `getNodeId` and return your custom identifier (works great in combination with `Sluggable`)
 
 <a name="translatable" id="translatable"></a>
 ### translatable:

--- a/src/Model/Tree/Node.php
+++ b/src/Model/Tree/Node.php
@@ -33,7 +33,7 @@ trait Node
 
     protected $materializedPath = '';
 
-    public function getTreeNodeField()
+    public function getNodeId()
     {
         return $this->getId();
     }
@@ -53,7 +53,7 @@ trait Node
      **/
     public function getRealMaterializedPath()
     {
-        return $this->getMaterializedPath() . self::getMaterializedPathSeparator() . $this->getTreeNodeField();
+        return $this->getMaterializedPath() . self::getMaterializedPathSeparator() . $this->getNodeId();
     }
 
     public function getMaterializedPath()
@@ -159,7 +159,7 @@ trait Node
      **/
     public function setChildNodeOf(NodeInterface $node)
     {
-        $id = $this->getTreeNodeField();
+        $id = $this->getNodeId();
         if (empty($id)) {
             throw new \LogicException('You must provide an id for this node if you want it to be part of a tree.');
         }
@@ -253,12 +253,12 @@ trait Node
             };
         }
         if (null === $tree) {
-            $tree = array($this->getTreeNodeField() => array('node' => $prepare($this), 'children' => array()));
+            $tree = array($this->getNodeId() => array('node' => $prepare($this), 'children' => array()));
         }
 
         foreach ($this->getChildNodes() as $node) {
-            $tree[$this->getTreeNodeField()]['children'][$node->getTreeNodeField()] = array('node' => $prepare($node), 'children' => array());
-            $node->toArray($prepare, $tree[$this->getTreeNodeField()]['children']);
+            $tree[$this->getNodeId()]['children'][$node->getNodeId()] = array('node' => $prepare($node), 'children' => array());
+            $node->toArray($prepare, $tree[$this->getNodeId()]['children']);
         }
 
         return $tree;
@@ -280,11 +280,11 @@ trait Node
             };
         }
         if (null === $tree) {
-            $tree = array($this->getTreeNodeField() => $prepare($this));
+            $tree = array($this->getNodeId() => $prepare($this));
         }
 
         foreach ($this->getChildNodes() as $node) {
-            $tree[$node->getTreeNodeField()] = $prepare($node);
+            $tree[$node->getNodeId()] = $prepare($node);
             $node->toFlatArray($prepare, $tree);
         }
 

--- a/src/Model/Tree/Node.php
+++ b/src/Model/Tree/Node.php
@@ -33,6 +33,11 @@ trait Node
 
     protected $materializedPath = '';
 
+    public function getTreeNodeField()
+    {
+        return $this->getId();
+    }
+
     /**
      * Returns path separator for entity's materialized path.
      *
@@ -48,7 +53,7 @@ trait Node
      **/
     public function getRealMaterializedPath()
     {
-        return $this->getMaterializedPath() . self::getMaterializedPathSeparator() . $this->getId();
+        return $this->getMaterializedPath() . self::getMaterializedPathSeparator() . $this->getTreeNodeField();
     }
 
     public function getMaterializedPath()
@@ -154,7 +159,7 @@ trait Node
      **/
     public function setChildNodeOf(NodeInterface $node)
     {
-        $id = $this->getId();
+        $id = $this->getTreeNodeField();
         if (empty($id)) {
             throw new \LogicException('You must provide an id for this node if you want it to be part of a tree.');
         }
@@ -248,12 +253,12 @@ trait Node
             };
         }
         if (null === $tree) {
-            $tree = array($this->getId() => array('node' => $prepare($this), 'children' => array()));
+            $tree = array($this->getTreeNodeField() => array('node' => $prepare($this), 'children' => array()));
         }
 
         foreach ($this->getChildNodes() as $node) {
-            $tree[$this->getId()]['children'][$node->getId()] = array('node' => $prepare($node), 'children' => array());
-            $node->toArray($prepare, $tree[$this->getId()]['children']);
+            $tree[$this->getTreeNodeField()]['children'][$node->getTreeNodeField()] = array('node' => $prepare($node), 'children' => array());
+            $node->toArray($prepare, $tree[$this->getTreeNodeField()]['children']);
         }
 
         return $tree;
@@ -275,11 +280,11 @@ trait Node
             };
         }
         if (null === $tree) {
-            $tree = array($this->getId() => $prepare($this));
+            $tree = array($this->getTreeNodeField() => $prepare($this));
         }
 
         foreach ($this->getChildNodes() as $node) {
-            $tree[$node->getId()] = $prepare($node);
+            $tree[$node->getTreeNodeField()] = $prepare($node);
             $node->toFlatArray($prepare, $tree);
         }
 

--- a/src/Model/Tree/NodeInterface.php
+++ b/src/Model/Tree/NodeInterface.php
@@ -13,9 +13,9 @@ use Doctrine\Common\Collections\Collection;
 interface NodeInterface
 {
     /**
-     * @return string the id that will represent the node in the path
+     * @return string the field that will represent the node in the path
      **/
-    public function getId();
+    public function getTreeNodeField();
 
     /**
      * @return string the materialized path,
@@ -110,4 +110,3 @@ interface NodeInterface
      **/
     public function buildTree(array $nodes);
 }
-

--- a/src/Model/Tree/NodeInterface.php
+++ b/src/Model/Tree/NodeInterface.php
@@ -15,7 +15,7 @@ interface NodeInterface
     /**
      * @return string the field that will represent the node in the path
      **/
-    public function getTreeNodeField();
+    public function getNodeId();
 
     /**
      * @return string the materialized path,


### PR DESCRIPTION
with this patch it is possible to another key than the `ID` for generating the materialized path. (i wanted to use the slug field instead)

you can override `getTreeNodeField` for that purpose:

```php
    public function getNodeId()
    {
        if (!$this->getSlug()) {
            $this->generateSlug();
        }

        return $this->getSlug();
    }
```