### PR TITLE
Handle overridden classes for Translatable 

### DIFF
--- a/src/Model/Translatable/TranslatableMethods.php
+++ b/src/Model/Translatable/TranslatableMethods.php
@@ -151,7 +151,7 @@ trait TranslatableMethods
      */
     public static function getTranslationEntityClass()
     {
-        return __CLASS__.'Translation';
+        return get_called_class() . 'Translation';
     }
 
     /**

--- a/src/ORM/Translatable/TranslatableSubscriber.php
+++ b/src/ORM/Translatable/TranslatableSubscriber.php
@@ -59,9 +59,10 @@ class TranslatableSubscriber extends AbstractSubscriber
      */
     public function loadClassMetadata(LoadClassMetadataEventArgs $eventArgs)
     {
+        /** @var ClassMetadata $classMetadata */
         $classMetadata = $eventArgs->getClassMetadata();
 
-        if (null === $classMetadata->reflClass) {
+        if (null === $classMetadata->reflClass || $classMetadata->isMappedSuperclass) {
             return;
         }
 


### PR DESCRIPTION
This enable to override translatable/translation classes and the use of mapped superclasses in mappings.
Note : get_called_class was introduced in PHP 5.3