### PR TITLE
travis: doctrine/common versions updated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,21 +6,17 @@ php:
   - 5.6
 
 env:
-  - DOCTRINE_COMMON_VERSION="~2.2.0" DB=mysql DB_USER=root PREFER=latest
-  - DOCTRINE_COMMON_VERSION="~2.3.0" DB=mysql DB_USER=root PREFER=latest
-  - DOCTRINE_COMMON_VERSION="~2.4.0" DB=mysql DB_USER=root PREFER=latest
+  - DOCTRINE_COMMON_VERSION="~2.4" DB=mysql DB_USER=root PREFER=latest
+  - DOCTRINE_COMMON_VERSION="~2.5" DB=mysql DB_USER=root PREFER=latest
   - DOCTRINE_COMMON_VERSION="dev-master" DB=mysql DB_USER=root PREFER=latest
-  - DOCTRINE_COMMON_VERSION="~2.2.0" DB=pgsql PREFER=latest
-  - DOCTRINE_COMMON_VERSION="~2.3.0" DB=pgsql PREFER=latest
-  - DOCTRINE_COMMON_VERSION="~2.4.0" DB=pgsql PREFER=latest
+  - DOCTRINE_COMMON_VERSION="~2.4" DB=pgsql PREFER=latest
+  - DOCTRINE_COMMON_VERSION="~2.5" DB=pgsql PREFER=latest
   - DOCTRINE_COMMON_VERSION="dev-master" DB=pgsql PREFER=latest
-  - DOCTRINE_COMMON_VERSION="~2.2.0" DB=mysql DB_USER=root PREFER=lowest
-  - DOCTRINE_COMMON_VERSION="~2.3.0" DB=mysql DB_USER=root PREFER=lowest
-  - DOCTRINE_COMMON_VERSION="~2.4.0" DB=mysql DB_USER=root PREFER=lowest
+  - DOCTRINE_COMMON_VERSION="~2.4" DB=mysql DB_USER=root PREFER=lowest
+  - DOCTRINE_COMMON_VERSION="~2.5" DB=mysql DB_USER=root PREFER=lowest
   - DOCTRINE_COMMON_VERSION="dev-master" DB=mysql DB_USER=root PREFER=lowest
-  - DOCTRINE_COMMON_VERSION="~2.2.0" DB=pgsql PREFER=lowest
-  - DOCTRINE_COMMON_VERSION="~2.3.0" DB=pgsql PREFER=lowest
-  - DOCTRINE_COMMON_VERSION="~2.4.0" DB=pgsql PREFER=lowest
+  - DOCTRINE_COMMON_VERSION="~2.4" DB=pgsql PREFER=lowest
+  - DOCTRINE_COMMON_VERSION="~2.5" DB=pgsql PREFER=lowest
   - DOCTRINE_COMMON_VERSION="dev-master" DB=pgsql PREFER=lowest
 
 before_script:


### PR DESCRIPTION
- 2.2, 2.3 are deprecated
- 2.5 was released