### PR TITLE
Use PropertyAccessor for get translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,9 +293,14 @@ so that when you try to call `getName` (for example) it will return you the tran
     {
         return $this->proxyCurrentLocaleTranslation($method, $arguments);
     }
-
+    
+    // or do it with PropertyAccessor that ships with Symfony SE
+    // if your methods don't take any required arguments
+    public function __call($method, $arguments)
+    {
+        return \Symfony\Component\PropertyAccess\PropertyAccess::createPropertyAccessor()->getValue($this->translate(), $method);
+    }
 ```
-
 
 <a name="softDeletable" id="softDeletable"></a>
 ### soft-deletable


### PR DESCRIPTION
Use `PropertyAccessor` instead of `proxyCurrentLocaleTranslation` to get translations.

In `PHP` scripts we simply could get translated heading by:
```php
$entity->getHeading();
```

But also it will be very useful for `Twig` templates:
``` jinja
<h1>{{ entity.heading }}</h1>
{# will be called "getHeading()", "heading()", "isHeading()", "hasHeading()" or "__get()" in this case #}
```