### PR TITLE
use psr logger instead of symfony logger

### DIFF
--- a/src/ORM/Loggable/LoggerCallable.php
+++ b/src/ORM/Loggable/LoggerCallable.php
@@ -11,7 +11,7 @@
 
 namespace Knp\DoctrineBehaviors\ORM\Loggable;
 
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * LoggerCallable can be invoked to log messages using symfony2 logger


### PR DESCRIPTION
the symfony logger is depreacted, use the psr logger is better here, since it allows usage outside of symfony aswell