### PR TITLE
[Sluggable] Add feature to generate unique slug

### DIFF
--- a/config/orm-services.yml
+++ b/config/orm-services.yml
@@ -154,4 +154,3 @@ services:
             - "%knp.doctrine_behaviors.sluggable_subscriber.sluggable_trait%"
         tags:
             - { name: doctrine.event_subscriber }
-

--- a/src/Model/Sluggable/SluggableMethods.php
+++ b/src/Model/Sluggable/SluggableMethods.php
@@ -42,6 +42,16 @@ trait SluggableMethods
     }
 
     /**
+     * Returns whether or not the unique slug gets regenerated.
+     *
+     * @return bool
+     */
+    public function getRegenerateUniqueSlug()
+    {
+        return false;
+    }
+
+    /**
      * Sets the entity's slug.
      *
      * @param $slug

--- a/src/Model/Sluggable/SluggableMethods.php
+++ b/src/Model/Sluggable/SluggableMethods.php
@@ -46,7 +46,7 @@ trait SluggableMethods
      *
      * @return bool
      */
-    public function shouldGenerateUniqueSlugs()
+    public static function shouldGenerateUniqueSlugs()
     {
         return false;
     }

--- a/src/Model/Sluggable/SluggableMethods.php
+++ b/src/Model/Sluggable/SluggableMethods.php
@@ -46,7 +46,7 @@ trait SluggableMethods
      *
      * @return bool
      */
-    public function getRegenerateUniqueSlug()
+    public function shouldGenerateUniqueSlugs()
     {
         return false;
     }

--- a/src/ORM/Sluggable/SluggableSubscriber.php
+++ b/src/ORM/Sluggable/SluggableSubscriber.php
@@ -109,12 +109,11 @@ class SluggableSubscriber extends AbstractSubscriber
      */
     private function generateUniqueSlugFor($entity, EntityManager $em)
     {
-        $classMetadata = $em->getClassMetadata(get_class($entity));
         $slug = $entity->getSlug();
         $uniqueSlug = $slug;
 
         $i = 0;
-        while ($em->getRepository($classMetadata->getName())->matching(
+        while ($em->getRepository(get_class($entity))->matching(
             Criteria::create()
                 ->andWhere(Criteria::expr()->neq('id', $entity->getId()))
                 ->andWhere(Criteria::expr()->eq('slug', $uniqueSlug))

--- a/src/ORM/Sluggable/SluggableSubscriber.php
+++ b/src/ORM/Sluggable/SluggableSubscriber.php
@@ -61,7 +61,7 @@ class SluggableSubscriber extends AbstractSubscriber
         if ($this->isSluggable($classMetadata)) {
             $entity->generateSlug();
 
-            if ($entity->getRegenerateUniqueSlug()) {
+            if ($entity->shouldGenerateUniqueSlugs()) {
                 $this->generateUniqueSlugFor($entity, $em);
             }
         }
@@ -76,7 +76,7 @@ class SluggableSubscriber extends AbstractSubscriber
         if ($this->isSluggable($classMetadata)) {
             $entity->generateSlug();
 
-            if ($entity->getRegenerateUniqueSlug()) {
+            if ($entity->shouldGenerateUniqueSlugs()) {
                 $this->generateUniqueSlugFor($entity, $em);
             }
         }

--- a/src/Repository/SluggableRepository.php
+++ b/src/Repository/SluggableRepository.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Knp\DoctrineBehaviors\Repository;
+
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityRepository;
+
+/**
+ * Class SluggableRepository
+ */
+class SluggableRepository extends EntityRepository
+{
+    /**
+     * @param EntityManager $em
+     * @param ClassMetadata $class
+     */
+    public function __construct(EntityManager $em, ClassMetadata $class)
+    {
+        parent::__construct($em, $class);
+    }
+
+    /**
+     * @param $entity
+     * @param $uniqueSlug
+     * @return int
+     */
+    public function isSlugUniqueFor($entity, $uniqueSlug)
+    {
+        $qb = $this->createQueryBuilder('e');
+        $qb
+            ->select('COUNT(e)')
+            ->andWhere('e.id != :id')
+            ->andWhere('e.slug = :slug')
+            ->setParameter('id', $entity->getId())
+            ->setParameter('slug', $uniqueSlug)
+        ;
+
+        return (int)$qb->getQuery()->getSingleScalarResult();
+    }
+}


### PR DESCRIPTION
Resolve issue #234 .

If the `SluggableMethods:: getRegenerateUniqueSlug()` method returns `true` - the `SluggableSubscriber` will generate unique slug for entity with counter at the end if slug already taken, for example:
