### PR TITLE
Add documentation to override the default naming strategy for translatable

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,16 +166,13 @@ You now have a working `Category` that behaves like:
 <a name="translatable" id="translatable"></a>
 ### translatable:
 
-If you're working on a `Category` entity, the `Translatable` behavior expects a
-**CategoryTranslation** entity by default. If you prefer to use a different class name for the translation entity,
-you should override the trait method `getTranslationEntityClass` in the translatable entity and `getTranslatableEntityClass`
-in the translation entity. If you override one, you also need to override the other to return the inverse class.
+If you're working on a `Category` entity, the `Translatable` behavior expects a **CategoryTranslation** entity in the 
+same folder of Category entity by default.
 
-The default naming convention (or its customization via trait methods) avoids you to handle manually entity associations.
+The default naming convention (or its customization via trait methods) avoids you to manually handle entity associations.
 It is handled automatically by the TranslationSubscriber.
 
 In order to use the Translatable trait, you will have to create this `CategoryTranslation` entity.
-
 
 ``` php
 <?php
@@ -259,7 +256,8 @@ class Category
 ```
 
 
-After updating the database, ie. with `./console doctrine:schema:update --force`, you can now work on translations using `translate` or `getTranslations` methods.
+After updating the database, ie. with `./console doctrine:schema:update --force`, 
+you can now work on translations using `translate` or `getTranslations` methods.
 
 ``` php
 <?php
@@ -275,6 +273,79 @@ After updating the database, ie. with `./console doctrine:schema:update --force`
     $category->translate('en')->getName();
 
 ```
+
+#### Override
+
+In case you prefer to use a different class name for the translation entity, 
+or want to use a separate namespace, you have 2 ways :
+
+If you want to define a custom translation entity class name globally :  
+Override the trait `Translatable` and his  method `getTranslationEntityClass` 
+and the trait `Translation` and his method `getTranslatableEntityClass` in the translation entity. 
+If you override one, you also need to override the other to return the inverse class.
+
+Example: Let's say you want to create a sub namespace AppBundle\Entity\Translation to stock translations classes 
+then put overrided traits in that folder.
+
+``` php
+<?php
+namespace AppBundle\Entity\Translation;
+
+use Knp\DoctrineBehaviors\Model\Translatable\Translatable;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+
+trait TranslatableTrait
+{
+    use Translatable;
+
+    /**
+     * @inheritdoc
+     */
+    public static function getTranslationEntityClass()
+    {
+        $explodedNamespace = explode('\\', __CLASS__);
+        $entityClass = array_pop($explodedNamespace);
+        return '\\'.implode('\\', $explodedNamespace).'\\Translation\\'.$entityClass.'Translation';
+    }
+}
+```
+
+``` php
+<?php
+namespace AppBundle\Entity\Translation;
+
+use Knp\DoctrineBehaviors\Model\Translatable\Translation;
+
+trait TranslationTrait
+{
+    use Translation;
+
+    /**
+     * @inheritdoc
+     */
+    public static function getTranslatableEntityClass()
+    {
+        $explodedNamespace = explode('\\', __CLASS__);
+        $entityClass = array_pop($explodedNamespace);
+        // Remove Translation namespace
+        array_pop($explodedNamespace);
+        return '\\'.implode('\\', $explodedNamespace).'\\'.substr($entityClass, 0, -11);
+    }
+}
+```
+
+If you use that way make sure you override trait parameters of DoctrineBehaviors :
+
+``` yaml
+parameters:
+    knp.doctrine_behaviors.translatable_subscriber.translatable_trait: AppBundle\Entity\Translation\TranslatableTrait
+    knp.doctrine_behaviors.translatable_subscriber.translation_trait: AppBundle\Entity\Translation\TranslationTrait
+```
+
+If you want to define a custom translation entity class name just for a single translatable class :  
+Override the trait method `getTranslationEntityClass` in the translatable entity and `getTranslatableEntityClass`
+in the translation entity. If you override one, you also need to override the other to return the inverse class.
+
 
 #### guess the current locale
 


### PR DESCRIPTION
Hello,

The documentation doesn't currently give a way to override default naming strategy globally for translatable behaviors.

I wrote this part of doc and re-organize some part.

ksom