### PR TITLE
Timestampable - add db field type parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,19 @@ so that when you try to call `getName` (for example) it will return you the tran
 
 ```
 
+If you wish to change the doctrine type of the database fields that will be created for timestampable models you can
+set the following parameter like so:
+
+``` yaml
+parameters:
+    knp.doctrine_behaviors.timestampable_subscriber.db_field_type: datetimetz
+```
+
+`datetimetz` here is a useful one to use if you are working with a Postgres database, otherwise you may encounter some
+timezone issues. For more information on this see: 
+<a href="http://doctrine-dbal.readthedocs.org/en/latest/reference/known-vendor-issues.html#datetime-datetimetz-and-time-types">http://doctrine-dbal.readthedocs.org/en/latest/reference/known-vendor-issues.html#datetime-datetimetz-and-time-types</a>
+
+The default type is `datetime`.
 
 <a name="blameable" id="blameable"></a>
 ### blameable

--- a/config/orm-services.yml
+++ b/config/orm-services.yml
@@ -12,6 +12,7 @@ parameters:
     knp.doctrine_behaviors.softdeletable_subscriber.softdeletable_trait: Knp\DoctrineBehaviors\Model\SoftDeletable\SoftDeletable
     knp.doctrine_behaviors.timestampable_subscriber.class: Knp\DoctrineBehaviors\ORM\Timestampable\TimestampableSubscriber
     knp.doctrine_behaviors.timestampable_subscriber.timestampable_trait: Knp\DoctrineBehaviors\Model\Timestampable\Timestampable
+    knp.doctrine_behaviors.timestampable_subscriber.db_field_type: datetime
     knp.doctrine_behaviors.blameable_subscriber.class: Knp\DoctrineBehaviors\ORM\Blameable\BlameableSubscriber
     knp.doctrine_behaviors.blameable_subscriber.blameable_trait: Knp\DoctrineBehaviors\Model\Blameable\Blameable
     knp.doctrine_behaviors.blameable_subscriber.user_callable.class: Knp\DoctrineBehaviors\ORM\Blameable\UserCallable
@@ -76,6 +77,7 @@ services:
             - "@knp.doctrine_behaviors.reflection.class_analyzer"
             - "%knp.doctrine_behaviors.reflection.is_recursive%"
             - "%knp.doctrine_behaviors.timestampable_subscriber.timestampable_trait%"
+            - "%knp.doctrine_behaviors.timestampable_subscriber.db_field_type%"
         tags:
             - { name: doctrine.event_subscriber }
 

--- a/src/ORM/Timestampable/TimestampableSubscriber.php
+++ b/src/ORM/Timestampable/TimestampableSubscriber.php
@@ -27,12 +27,14 @@ use Doctrine\ORM\Event\LoadClassMetadataEventArgs,
 class TimestampableSubscriber extends AbstractSubscriber
 {
     private $timestampableTrait;
+    private $dbFieldType;
 
-    public function __construct(ClassAnalyzer $classAnalyzer, $isRecursive, $timestampableTrait)
+    public function __construct(ClassAnalyzer $classAnalyzer, $isRecursive, $timestampableTrait, $dbFieldType)
     {
         parent::__construct($classAnalyzer, $isRecursive);
 
         $this->timestampableTrait = $timestampableTrait;
+        $this->dbFieldType = $dbFieldType;
     }
 
     public function loadClassMetadata(LoadClassMetadataEventArgs $eventArgs)
@@ -53,7 +55,7 @@ class TimestampableSubscriber extends AbstractSubscriber
                 if (!$classMetadata->hasField($field)) {
                     $classMetadata->mapField(array(
                         'fieldName' => $field,
-                        'type'      => 'datetime',
+                        'type'      => $this->dbFieldType,
                         'nullable'  => true
                     ));
                 }

--- a/tests/Knp/DoctrineBehaviors/ORM/TimestampableTest.php
+++ b/tests/Knp/DoctrineBehaviors/ORM/TimestampableTest.php
@@ -26,7 +26,8 @@ class TimestampableTest extends \PHPUnit_Framework_TestCase
             new \Knp\DoctrineBehaviors\ORM\Timestampable\TimestampableSubscriber(
                 new ClassAnalyzer(),
                 false,
-                'Knp\DoctrineBehaviors\Model\Timestampable\Timestampable'
+                'Knp\DoctrineBehaviors\Model\Timestampable\Timestampable',
+                'datetime'
         ));
 
         return $em;


### PR DESCRIPTION
We came across this issue when working with a Postgres database. The `datetime` field in pg ignores the timezone which was causing us some headaches. This PR allows you to define the field type as a parameter rather than (as we have done in our current project) overriding the whole subscriber class - which, incidentally, has a number of private methods and properties which make for an unnecessarily large override file. Have added some docs too.