### PR TITLE
Language only fallback

### DIFF
--- a/src/Model/Translatable/TranslatableMethods.php
+++ b/src/Model/Translatable/TranslatableMethods.php
@@ -104,10 +104,9 @@ trait TranslatableMethods
         }
 
         if ($fallbackToDefault) {
-            if ($fallbackLocale = $this->computeFallbackLocale($locale)) {
-                if ($translation = $this->findTranslationByLocale($fallbackLocale)) {
-                    return $translation;
-                }
+            if (($fallbackLocale = $this->computeFallbackLocale($locale))
+                && ($translation = $this->findTranslationByLocale($fallbackLocale))) {
+                return $translation;
             }
 
             if ($defaultTranslation = $this->findTranslationByLocale($this->getDefaultLocale(), false)) {

--- a/src/Model/Translatable/TranslatableMethods.php
+++ b/src/Model/Translatable/TranslatableMethods.php
@@ -103,8 +103,16 @@ trait TranslatableMethods
             return $translation;
         }
 
-        if ($fallbackToDefault && $defaultTranslation = $this->findTranslationByLocale($this->getDefaultLocale(), false)) {
-            return $defaultTranslation;
+        if ($fallbackToDefault) {
+            if ($fallbackLocale = $this->computeFallbackLocale($locale)) {
+                if ($translation = $this->findTranslationByLocale($fallbackLocale)) {
+                    return $translation;
+                }
+            }
+
+            if ($defaultTranslation = $this->findTranslationByLocale($this->getDefaultLocale(), false)) {
+                return $defaultTranslation;
+            }
         }
 
         $class       = self::getTranslationEntityClass();
@@ -207,5 +215,14 @@ trait TranslatableMethods
         if ($withNewTranslations) {
             return $this->getNewTranslations()->get($locale);
         }
+    }
+
+    protected function computeFallbackLocale($locale)
+    {
+        if (strrchr($locale, '_') !== false) {
+            return substr($locale, 0, -strlen(strrchr($locale, '_')));
+        }
+
+        return false;
     }
 }

--- a/tests/Knp/DoctrineBehaviors/ORM/TranslatableTest.php
+++ b/tests/Knp/DoctrineBehaviors/ORM/TranslatableTest.php
@@ -86,6 +86,45 @@ class TranslatableTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function should_fallback_country_locale_to_language_only_translation()
+    {
+        $em = $this->getEntityManager();
+
+        $entity = new \BehaviorFixtures\ORM\TranslatableEntity();
+        $entity->translate('en', false)->setTitle('plastic bag');
+        $entity->translate('fr', false)->setTitle('sac plastique');
+        $entity->translate('fr_CH', false)->setTitle('cornet');
+        $entity->mergeNewTranslations();
+
+        $em->persist($entity);
+        $em->flush();
+        $id = $entity->getId();
+        $em->clear();
+
+        $entity = $em
+            ->getRepository('BehaviorFixtures\ORM\TranslatableEntity')
+            ->find($id)
+        ;
+
+        $this->assertEquals(
+            'plastic bag',
+            $entity->translate('de')->getTitle()
+        );
+
+        $this->assertEquals(
+            'sac plastique',
+            $entity->translate('fr_FR')->getTitle()
+        );
+
+        $this->assertEquals(
+            'cornet',
+            $entity->translate('fr_CH')->getTitle()
+        );
+    }
+
+    /**
+     * @test
+     */
     public function should_update_and_add_new_translations()
     {
         $em = $this->getEntityManager();


### PR DESCRIPTION
When working with **language_COUNTRY** locales, it is common to fallback to language only translations. However, Translatable could only fallback to the default locale. This PR fixes this.

Maybe it has to be enhanced, as it uses the same **$fallbackToDefault** parameter as the one that already exists, but its usage isn't quite the same. If you previously relied on the fallback of **fr_FR** to **en** instead of **fr**, you will have a BC break (currently no unit tests show this).

See the code of the [Symfony translation component](https://github.com/symfony/translation/blob/master/Translator.php#L392) for reference.