### PR TITLE
Make Behaviors configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@ Make sure to activate them by reading the [Subscribers](#subscribers) section.
 ##Installation
 ```composer require knplabs/doctrine-behaviors:~1.1```
 
+## Configuration
+By default, when integrated with Symfony, all subscribers are enabled (if you don't specify any configuration for the bundle).
+But you can enable behaviors you need in a whitelist manner:
+```yaml
+knp_doctrine_behaviors:
+    blameable:      false
+    geocodable:     ~     # Here null is converted to false
+    loggable:       ~
+    sluggable:      true
+    soft_deletable: true
+    # All others behaviors are disabled
+```
+
 <a name="subscribers" id="subscribers"></a>
 ## Subscribers
 

--- a/src/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bundle/DependencyInjection/Configuration.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Knp\DoctrineBehaviors\Bundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class Configuration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder()
+    {
+        $builder = new TreeBuilder();
+        $builder
+            ->root('knp_doctrine_behaviors')
+            ->treatNullLike([
+                'blameable'      => true,
+                'geocodable'     => true,
+                'loggable'       => true,
+                'sluggable'      => true,
+                'soft_deletable' => true,
+                'sortable'       => true,
+                'timestampable'  => true,
+                'translatable'   => true,
+                'tree'           => true,
+            ])->children()
+                ->booleanNode('blameable')->defaultFalse()->treatNullLike(false)->end()
+                ->booleanNode('geocodable')->defaultFalse()->treatNullLike(false)->end()
+                ->booleanNode('loggable')->defaultFalse()->treatNullLike(false)->end()
+                ->booleanNode('sluggable')->defaultFalse()->treatNullLike(false)->end()
+                ->booleanNode('soft_deletable')->defaultFalse()->treatNullLike(false)->end()
+                ->booleanNode('sortable')->defaultFalse()->treatNullLike(false)->end()
+                ->booleanNode('timestampable')->defaultFalse()->treatNullLike(false)->end()
+                ->booleanNode('translatable')->defaultFalse()->treatNullLike(false)->end()
+                ->booleanNode('tree')->defaultFalse()->treatNullLike(false)->end()
+            ->end()
+        ;
+
+        return $builder;
+    }
+}

--- a/src/Bundle/DependencyInjection/DoctrineBehaviorsExtension.php
+++ b/src/Bundle/DependencyInjection/DoctrineBehaviorsExtension.php
@@ -3,6 +3,7 @@
 namespace Knp\DoctrineBehaviors\Bundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
@@ -16,5 +17,22 @@ class DoctrineBehaviorsExtension extends Extension
     {
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../../../config'));
         $loader->load('orm-services.yml');
+
+        $configuration = new Configuration();
+        $config = $this->processConfiguration($configuration, $configs);
+
+        foreach ($config as $behavior => $enabled) {
+            if (!$enabled) {
+                $container->removeDefinition(sprintf('knp.doctrine_behaviors.%s_subscriber', $behavior));
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAlias()
+    {
+        return 'knp_doctrine_behaviors';
     }
 }

--- a/src/Bundle/DoctrineBehaviorsBundle.php
+++ b/src/Bundle/DoctrineBehaviorsBundle.php
@@ -2,9 +2,13 @@
 
 namespace Knp\DoctrineBehaviors\Bundle;
 
+use Knp\DoctrineBehaviors\Bundle\DependencyInjection\DoctrineBehaviorsExtension;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class DoctrineBehaviorsBundle extends Bundle
 {
-
+    public function getContainerExtension()
+    {
+        return new DoctrineBehaviorsExtension();
+    }
 }


### PR DESCRIPTION
You can now enable/disable behaviors you don't want using the bundle config.
By default, all behaviors are enabled. As soon as `knp_doctrine_behaviors` is
specified, all behaviors are disabled and the developer need to specify which
ones he want to enable.

This fix conflict issues, for example when a `setCurrentLocale` method is
defined by another third-party library/bundle.

This way does not introduce BC breaks, but only a new feature. The best would
be to add some interfaces and use them in subscribers. But that would imply
a major release... Maybe for the next one :-)