### PR TITLE
Translatable: enable cascade persist and merge on the owning side 

### DIFF
--- a/src/ORM/Translatable/TranslatableSubscriber.php
+++ b/src/ORM/Translatable/TranslatableSubscriber.php
@@ -218,6 +218,7 @@ class TranslatableSubscriber extends AbstractSubscriber
             $classMetadata->mapManyToOne([
                 'fieldName'    => 'translatable',
                 'inversedBy'   => 'translations',
+                'cascade'       => ['persist', 'merge'],
                 'fetch'         => $this->translationFetchMode,
                 'joinColumns'  => [[
                     'name'                 => 'translatable_id',

--- a/src/ORM/Translatable/TranslatableSubscriber.php
+++ b/src/ORM/Translatable/TranslatableSubscriber.php
@@ -218,8 +218,8 @@ class TranslatableSubscriber extends AbstractSubscriber
             $classMetadata->mapManyToOne([
                 'fieldName'    => 'translatable',
                 'inversedBy'   => 'translations',
-                'cascade'       => ['persist', 'merge'],
-                'fetch'         => $this->translationFetchMode,
+                'cascade'      => ['persist', 'merge'],
+                'fetch'        => $this->translationFetchMode,
                 'joinColumns'  => [[
                     'name'                 => 'translatable_id',
                     'referencedColumnName' => 'id',


### PR DESCRIPTION
When starting from the owning side (translation entity) it could be nice to save the reversed side (translatable entity) automatically. So I enabled cascade merge and persist when mapping a translation in the TranslatableSubscriber.php. 