### PR TITLE
Fixes compatibility for Symfony 3.0

### DIFF
--- a/src/ORM/Translatable/CurrentLocaleCallable.php
+++ b/src/ORM/Translatable/CurrentLocaleCallable.php
@@ -19,13 +19,18 @@ class CurrentLocaleCallable
 
     public function __invoke()
     {
-        if (!$this->container->isScopeActive('request')) {
-            return;
+        if (!$this->container->has('request_stack')) {
+            if(!$this->container->isScopeActive('request')) {
+                return NULL;
+            }
+            $request = $this->container->get('request');
+
+            return $request->getLocale();
+        } else if ($request = $this->container->get('request_stack')->getCurrentRequest()) {
+            return $request->getLocale();
         }
 
-        $request = $this->container->get('request');
-
-        return $request->getLocale();
+        return NULL;
     }
 }
 


### PR DESCRIPTION
In Symfony 3.0, scopes and the 'request' service have been removed.
This commit fixes that while preserving BC.