### PR TITLE
Update UserCallable.php

### DIFF
--- a/src/ORM/Blameable/UserCallable.php
+++ b/src/ORM/Blameable/UserCallable.php
@@ -34,7 +34,7 @@ class UserCallable
 
     public function __invoke()
     {
-        $token = $this->container->get('security.context')->getToken();
+        $token = $this->container->get('security.token_storage')->getToken();
         if (null !== $token) {
             return $token->getUser();
         }


### PR DESCRIPTION
security.context service is deprecated since Symfony 3.x and will trigger an exception

You have requested a non-existent service "security.context"

It must be changed to security.token_storage. Changing configuration to custom UserCallable helps but is only a dirty hack it this case :)

    knp.doctrine_behaviors.blameable_subscriber.user_callable.class:     WellCommerce\Bundle\CoreBundle\Doctrine\ORM\Blameable\UserCallable

Another approach is to inject token storage instead of whole container. 

* Here's the example class:

https://github.com/WellCommerce/WellCommerce/blob/development/src/WellCommerce/Bundle/CoreBundle/Doctrine/ORM/Blameable/UserCallable.php

* and modified service definition:

https://github.com/WellCommerce/WellCommerce/blob/development/src/WellCommerce/Bundle/AppBundle/Resources/config/wellcommerce.yml#L157-L161
