### PR TITLE
Fixes Travis checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ matrix:
   fast_finish: true
   allow_failures:
     - php: 7.0
+  exclude:
+    - php: 5.4
+        env: DOCTRINE_COMMON_VERSION="dev-master"
 
 env:
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,13 @@ matrix:
     - php: 7.0
   exclude:
     - php: 5.4
-      env: DOCTRINE_COMMON_VERSION="dev-master"
+      env: DOCTRINE_COMMON_VERSION="dev-master" DB=mysql DB_USER=root PREFER=latest
+    - php: 5.4
+      env: DOCTRINE_COMMON_VERSION="dev-master" DB=pgsql PREFER=latest
+    - php: 5.4
+      env: DOCTRINE_COMMON_VERSION="dev-master" DB=mysql DB_USER=root PREFER=lowest
+    - php: 5.4
+      env: DOCTRINE_COMMON_VERSION="dev-master" DB=pgsql PREFER=lowest
 
 env:
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
     - php: 7.0
   exclude:
     - php: 5.4
-        env: DOCTRINE_COMMON_VERSION="dev-master"
+      env: DOCTRINE_COMMON_VERSION="dev-master"
 
 env:
   matrix:


### PR DESCRIPTION
Doctrine dev-master is incompatibel with PHP 5.4, which causes Travis to error. This PR excludes that configuration, so it will not error anymore.