### PR TITLE
Microseconds

### DIFF
--- a/src/Model/Loggable/Loggable.php
+++ b/src/Model/Loggable/Loggable.php
@@ -27,7 +27,7 @@ trait Loggable
         foreach ($changeSets as $property => $changeSet) {
             for ($i = 0, $s = sizeof($changeSet); $i < $s; $i++) {
                 if ($changeSet[$i] instanceof \DateTime) {
-                    $changeSet[$i] = $changeSet[$i]->format("Y-m-d H:i:s");
+                    $changeSet[$i] = $changeSet[$i]->format("Y-m-d H:i:s.u");
                 }
             }
 

--- a/src/Model/SoftDeletable/SoftDeletableMethods.php
+++ b/src/Model/SoftDeletable/SoftDeletableMethods.php
@@ -23,7 +23,7 @@ trait SoftDeletableMethods
      */
     public function delete()
     {
-        $this->deletedAt = new \DateTime();
+        $this->deletedAt = $this->currentDateTime();
     }
 
     /**
@@ -42,7 +42,7 @@ trait SoftDeletableMethods
     public function isDeleted()
     {
         if (null !== $this->deletedAt) {
-            return $this->deletedAt <= (new \DateTime());
+            return $this->deletedAt <= $this->currentDateTime();
         }
 
         return false;
@@ -90,5 +90,18 @@ trait SoftDeletableMethods
         $this->deletedAt = $date;
 
         return $this;
+    }
+
+    /**
+     * Get a instance of \DateTime with the current data time including milliseconds.
+     *
+     * @return \DateTime
+     */
+    private function currentDateTime()
+    {
+        $dateTime = \DateTime::createFromFormat('U.u', sprintf('%.6F', microtime(true)));
+        $dateTime->setTimezone(new \DateTimeZone(date_default_timezone_get()));
+
+        return $dateTime;
     }
 }

--- a/src/Model/Timestampable/TimestampableMethods.php
+++ b/src/Model/Timestampable/TimestampableMethods.php
@@ -65,10 +65,14 @@ trait TimestampableMethods
      */
     public function updateTimestamps()
     {
+        // Create a datetime with microseconds
+        $dateTime = \DateTime::createFromFormat('U.u', sprintf('%.6F', microtime(true)));
+        $dateTime->setTimezone(new \DateTimeZone(date_default_timezone_get()));
+
         if (null === $this->createdAt) {
-            $this->createdAt = new \DateTime('now');
+            $this->createdAt = $dateTime;
         }
 
-        $this->updatedAt = new \DateTime('now');
+        $this->updatedAt = $dateTime;
     }
 }

--- a/tests/Knp/DoctrineBehaviors/ORM/LoggableTest.php
+++ b/tests/Knp/DoctrineBehaviors/ORM/LoggableTest.php
@@ -144,7 +144,7 @@ class LoggableTest extends \PHPUnit_Framework_TestCase
                 "roles", array("x" => "y"), "an array"
             ),
             array(
-                "date", new \DateTime("2014-02-02 12:20:30"), "2014-02-02 12:20:30"
+                "date", new \DateTime("2014-02-02 12:20:30.000010"), "2014-02-02 12:20:30.000010"
             )
         );
     }


### PR DESCRIPTION
Hi there,

So I was writing some tests and found out that the Timestampable, SoftDeletable and Loggable behaviours where ignoring microseconds which was causing some issue in my enviroment.

This PR adds microseconds to the Timestampable, SoftDeletable and Loggable behaviours. 

Let me know what you think.

Cheers,
Warnar

P.S. the `$dateTime->setTimezone` is needed because for some reason the unix timestamp changes based on the timezone in PHP.
