### PR TITLE
TranslatableMethods: use late static bindings

### DIFF
--- a/src/Model/Translatable/TranslatableMethods.php
+++ b/src/Model/Translatable/TranslatableMethods.php
@@ -114,7 +114,7 @@ trait TranslatableMethods
             }
         }
 
-        $class       = self::getTranslationEntityClass();
+        $class       = static::getTranslationEntityClass();
         $translation = new $class();
         $translation->setLocale($locale);
 


### PR DESCRIPTION
Use late static bindings (replace `self::` by `static::`) for `TranslatableMethods::doTranslate()`.

Use case:
```php
abstract class Foo
{
    use Translatable;
}

class Baz
{
    use Translation;

    public static function getTranslatableEntityClass()
    {
        return Bar::class;
    }
}

class Bar extends Foo
{
    public static function getTranslationEntityClass()
    {
        return Baz::class;
    }
}