### PR TITLE
Updated master branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.1.x-dev"
+            "dev-master": "1.3.x-dev"
         }
     }
 }


### PR DESCRIPTION
Hi there,

This is just a plain simple dump of the master branch alias so people using master because a PR was merged but not yet released can use something like ~1.3, >= 1.3.3 and it will pick up the master branch.
