### PR TITLE
Typecast parameter to int

### DIFF
--- a/src/Model/Sortable/Sortable.php
+++ b/src/Model/Sortable/Sortable.php
@@ -27,8 +27,9 @@ trait Sortable
      */
     public function setSort($sort)
     {
+        $sort = (int)$sort;
         $this->reordered = $this->sort !== $sort;
-        $this->sort      = $sort;
+        $this->sort = $sort;
 
         return $this;
     }


### PR DESCRIPTION
We use strict comparison of types (`!==`) below:

```php
$this->reordered = $this->sort !== $sort;
```