### PR TITLE
Fixes for Symfony 3.1

### DIFF
--- a/config/orm-services.yml
+++ b/config/orm-services.yml
@@ -57,7 +57,7 @@ services:
     knp.doctrine_behaviors.translatable_subscriber.default_locale_callable:
         class:           "%knp.doctrine_behaviors.translatable_subscriber.default_locale_callable.class%"
         arguments:
-            - %locale%
+            - "%locale%"
         public:  false
 
     knp.doctrine_behaviors.softdeletable_subscriber:


### PR DESCRIPTION
Not quoting a scalar starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0.

https://github.com/symfony/symfony/blob/3.1/UPGRADE-3.1.md#yaml