### PR TITLE
Fix interaction between translations & joined inheritance

### DIFF
--- a/config/orm-services.yml
+++ b/config/orm-services.yml
@@ -38,7 +38,6 @@ services:
         public:  false
         arguments:
             - "@knp.doctrine_behaviors.reflection.class_analyzer"
-            - "%knp.doctrine_behaviors.reflection.is_recursive%"
             - "@knp.doctrine_behaviors.translatable_subscriber.current_locale_callable"
             - "@knp.doctrine_behaviors.translatable_subscriber.default_locale_callable"
             - "%knp.doctrine_behaviors.translatable_subscriber.translatable_trait%"

--- a/src/ORM/Translatable/TranslatableSubscriber.php
+++ b/src/ORM/Translatable/TranslatableSubscriber.php
@@ -41,11 +41,11 @@ class TranslatableSubscriber extends AbstractSubscriber
     private $translatableFetchMode;
     private $translationFetchMode;
 
-    public function __construct(ClassAnalyzer $classAnalyzer, $isRecursive, callable $currentLocaleCallable = null,
+    public function __construct(ClassAnalyzer $classAnalyzer, callable $currentLocaleCallable = null,
                                 callable $defaultLocaleCallable = null,$translatableTrait, $translationTrait,
                                 $translatableFetchMode, $translationFetchMode)
     {
-        parent::__construct($classAnalyzer, $isRecursive);
+        parent::__construct($classAnalyzer, false);
 
         $this->currentLocaleCallable = $currentLocaleCallable;
         $this->defaultLocaleCallable = $defaultLocaleCallable;
@@ -280,22 +280,24 @@ class TranslatableSubscriber extends AbstractSubscriber
      * Checks if entity is translatable
      *
      * @param ClassMetadata $classMetadata
-     * @param bool          $isRecursive   true to check for parent classes until found
      *
      * @return boolean
      */
-    private function isTranslatable(ClassMetadata $classMetadata, $isRecursive = false)
+    private function isTranslatable(ClassMetadata $classMetadata)
     {
-        return $this->getClassAnalyzer()->hasTrait($classMetadata->reflClass, $this->translatableTrait, $this->isRecursive);
+        return $this->getClassAnalyzer()->hasTrait($classMetadata->reflClass, $this->translatableTrait);
     }
 
     /**
-     * @param  ClassMetadata $classMetadata
+     * Checks if entity is a translation
+     *
+     * @param ClassMetadata $classMetadata
+     *
      * @return boolean
      */
     private function isTranslation(ClassMetadata $classMetadata)
     {
-        return $this->getClassAnalyzer()->hasTrait($classMetadata->reflClass, $this->translationTrait, $this->isRecursive);
+        return $this->getClassAnalyzer()->hasTrait($classMetadata->reflClass, $this->translationTrait);
     }
 
     public function postLoad(LifecycleEventArgs $eventArgs)

--- a/tests/Knp/DoctrineBehaviors/ORM/TranslatableTest.php
+++ b/tests/Knp/DoctrineBehaviors/ORM/TranslatableTest.php
@@ -26,7 +26,6 @@ class TranslatableTest extends \PHPUnit_Framework_TestCase
 
         $em->addEventSubscriber(new \Knp\DoctrineBehaviors\ORM\Translatable\TranslatableSubscriber(
             new ClassAnalyzer(),
-            false,
             function()
             {
                 return 'en';


### PR DESCRIPTION
When using a JoinedInheritance for translations, the `TranslatableSubscriber` will try to map the children classes, which will create a new unique index on a column existing only in the parent class' table (`translatable_id`).

This crashes Doctrine.

Anyway, the fields need, associations and indexes only to be mapped for the root class of the translation hierarchy, since they will all be inherited. This is true for every kind of inheritance and every behaviour.

This PR fixes the issue for Translatable.