### PR TITLE
[Blameable] Remove scheduleExtraUpdate calls

### DIFF
--- a/src/ORM/Blameable/BlameableSubscriber.php
+++ b/src/ORM/Blameable/BlameableSubscriber.php
@@ -164,9 +164,6 @@ class BlameableSubscriber extends AbstractSubscriber
                     $entity->setCreatedBy($user);
 
                     $uow->propertyChanged($entity, 'createdBy', null, $user);
-                    $uow->scheduleExtraUpdate($entity, [
-                        'createdBy' => [null,  $user],
-                    ]);
                 }
             }
             if (!$entity->getUpdatedBy()) {
@@ -174,10 +171,6 @@ class BlameableSubscriber extends AbstractSubscriber
                 if ($this->isValidUser($user)) {
                     $entity->setUpdatedBy($user);
                     $uow->propertyChanged($entity, 'updatedBy', null, $user);
-
-                    $uow->scheduleExtraUpdate($entity, [
-                        'updatedBy' => [null, $user],
-                    ]);
                 }
             }
         }
@@ -220,10 +213,6 @@ class BlameableSubscriber extends AbstractSubscriber
                 $oldValue = $entity->getUpdatedBy();
                 $entity->setUpdatedBy($user);
                 $uow->propertyChanged($entity, 'updatedBy', $oldValue, $user);
-
-                $uow->scheduleExtraUpdate($entity, [
-                    'updatedBy' => [$oldValue, $user],
-                ]);
             }
         }
     }
@@ -249,10 +238,6 @@ class BlameableSubscriber extends AbstractSubscriber
                 $oldValue = $entity->getDeletedBy();
                 $entity->setDeletedBy($user);
                 $uow->propertyChanged($entity, 'deletedBy', $oldValue, $user);
-
-                $uow->scheduleExtraUpdate($entity, [
-                    'deletedBy' => [$oldValue, $user],
-                ]);
             }
         }
     }

--- a/src/ORM/Geocodable/GeocodableSubscriber.php
+++ b/src/ORM/Geocodable/GeocodableSubscriber.php
@@ -131,12 +131,6 @@ class GeocodableSubscriber extends AbstractSubscriber
                 }
 
                 $uow->propertyChanged($entity, 'location', $oldValue, $entity->getLocation());
-                $uow->scheduleExtraUpdate(
-                    $entity,
-                    [
-                        'location' => [$oldValue, $entity->getLocation()],
-                    ]
-                );
             }
         }
     }

--- a/tests/Knp/DoctrineBehaviors/ORM/EntityManagerProvider.php
+++ b/tests/Knp/DoctrineBehaviors/ORM/EntityManagerProvider.php
@@ -2,6 +2,7 @@
 
 namespace tests\Knp\DoctrineBehaviors\ORM;
 
+use Doctrine\DBAL\Logging\DebugStack;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\EntityManager;
@@ -169,6 +170,15 @@ trait EntityManagerProvider
             ->will($this->returnValue([]))
         ;
 
+        $logger = new DebugStack();
+        $logger->enabled = false;
+
+        $config
+            ->expects($this->any())
+            ->method('getSQLLogger')
+            ->will($this->returnValue($logger))
+        ;
+
         return $config;
     }
 
@@ -190,5 +200,19 @@ trait EntityManagerProvider
     protected function getEventManager()
     {
         return new EventManager;
+    }
+
+    /**
+     * Get SQL logger
+     *
+     * @return DebugStack
+     */
+    protected function getSqlLogger()
+    {
+        return $this->em
+            ->getConnection()
+            ->getConfiguration()
+            ->getSQLLogger()
+        ;
     }
 }

--- a/tests/Knp/DoctrineBehaviors/ORM/SoftDeletableTest.php
+++ b/tests/Knp/DoctrineBehaviors/ORM/SoftDeletableTest.php
@@ -44,9 +44,16 @@ class SoftDeletableTest extends \PHPUnit_Framework_TestCase
         $this->assertNotNull($id = $entity->getId());
         $this->assertFalse($entity->isDeleted());
 
+        $logger = $this->getSqlLogger();
+        $logger->enabled = true;
+
         $em->remove($entity);
         $em->flush();
-        $em->clear();
+
+        $this->assertCount(3, $logger->queries);
+        $this->assertEquals('"START TRANSACTION"', $logger->queries[1]['sql']);
+        $this->assertEquals('UPDATE DeletableEntity SET deletedAt = ? WHERE id = ?', $logger->queries[2]['sql']);
+        $this->assertEquals('"COMMIT"', $logger->queries[3]['sql']);
 
         $entity = $em->getRepository('BehaviorFixtures\ORM\DeletableEntity')->find($id);
 


### PR DESCRIPTION
# Issue

`BlameableSubscriber` (at least) is **always** doing an extra database update after inserting/updating an entity. It seems to be caused by the `scheduleExtraUpdate` calls.

This is especially annoying because I use doctrine version locking, and the version is incrementing 2 by 2.
## Examples (simplified)
### Insert

```
INSERT INTO my_table (created_by_id, updated_by_id) VALUES (?, ?) {"3":2,"4":2}
UPDATE my_table SET created_by_id = ?, version = version + 1 WHERE id = ? AND version = ? [2,503,1]
```
### Update

```
UPDATE my_table SET updated_by_id = ?, version = version + 1 WHERE id = ? AND version = ? [2,502,6]
UPDATE my_table SET updated_by_id = ?, version = version + 1 WHERE id = ? AND version = ? [2,502,7]
```
# Solution

Removing these calls fixes the issue : only 1 insert or update is performed, and the createdBy and updatedBy are inserted/updated correctly.
## Examples (simplified)
### Insert

```
INSERT INTO my_table (created_by_id, updated_by_id) VALUES (?, ?) {2, 2}
```
### Update

```
UPDATE my_table SET updated_by_id = ?, version = version + 1 WHERE id = ? AND version = ? [2,502,2]
```
# Conclusion

I'm not sure about the side effects of removing this call, please feel free to comment this PR !
