### PR TITLE
Run PHPUnit in normal mode instead of --testdox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,4 +57,4 @@ before_script:
 script:
   - bin/parallel-lint -e php,phpt --exclude vendor .
   - bin/yaml-lint config/*
-  - bin/phpunit --testdox
+  - bin/phpunit


### PR DESCRIPTION
In `--testdox` mode we can't see what exactly causes errors