### PR TITLE
Fix disabling softdeletable

### DIFF
--- a/src/Bundle/DependencyInjection/DoctrineBehaviorsExtension.php
+++ b/src/Bundle/DependencyInjection/DoctrineBehaviorsExtension.php
@@ -21,6 +21,10 @@ class DoctrineBehaviorsExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
+        // Don't rename in Configuration for BC reasons
+        $config['softdeletable'] = $config['soft_deletable'];
+        unset($config['soft_deletable']);
+
         foreach ($config as $behavior => $enabled) {
             if (!$enabled) {
                 $container->removeDefinition(sprintf('knp.doctrine_behaviors.%s_subscriber', $behavior));


### PR DESCRIPTION
In `orm-services.yml` the service defined as `knp.doctrine_behaviors.softdeletable_subscriber` but `DoctrineBehaviorsExtension` tries to remove `knp.doctrine_behaviors.soft_deletable_subscriber`