### PR TITLE
Fix doctrine/orm dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
 
 matrix:
   fast_finish: true

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "ext-pdo_sqlite":                   "*",
         "ext-pdo_mysql":                    "*",
         "ext-pdo_pgsql":                    "*",
-        "doctrine/orm":                     ">=2.2",
+        "doctrine/orm":                     ">=2.4.5",
         "phpunit/phpunit":                  "~4.8",
         "jakub-onderka/php-parallel-lint":  "~0.8",
         "hexmedia/yaml-linter":             "~0.1"


### PR DESCRIPTION
Tests are failing on master with doctrine common dev-master, with some PHP versions (<= 7.0).
Updated the matrix on Travis to add tests with PHP 7.1
doctrine/orm v2.3 support is dropped, since it's not maintained anymore.