### PR TITLE
[Translatable] Fix #362 - Prevent duplicate translation entry

### DIFF
--- a/src/Model/Translatable/TranslatableMethods.php
+++ b/src/Model/Translatable/TranslatableMethods.php
@@ -114,6 +114,10 @@ trait TranslatableMethods
             }
         }
 
+        if ($translation) {
+            return $translation;
+        }
+
         $class       = static::getTranslationEntityClass();
         $translation = new $class();
         $translation->setLocale($locale);


### PR DESCRIPTION
Even if a translation is empty, it should be returned if no fallback was found. Creating a new one, cause a duplicate entry.