### PR TITLE
Shrink locale columns to 5 chars

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,9 @@
+# 2.0.0
+
+Translatable:
+* `locale` columns are now capped at 5 chars. You might need to manually define
+  `locale` mapping, if you store anything lengthier.
+
 # 1.0.2 to 1.0.x-dev
 
 Most occurences of "listener" have been replaced with "subscriber" to honor a

--- a/src/ORM/Translatable/TranslatableSubscriber.php
+++ b/src/ORM/Translatable/TranslatableSubscriber.php
@@ -237,10 +237,11 @@ class TranslatableSubscriber extends AbstractSubscriber
         }
 
         if (!($classMetadata->hasField('locale') || $classMetadata->hasAssociation('locale'))) {
-            $classMetadata->mapField(array(
+            $classMetadata->mapField([
                 'fieldName' => 'locale',
-                'type'      => 'string'
-            ));
+                'type'      => 'string',
+                'length'    => 5,
+            ]);
         }
 
     }


### PR DESCRIPTION
Currently, the mapping for locale columns does not provide any length,
thus Doctrine falls back to the default size: 255 chars.

Not only such size is useless, but it also prevents using this library
with utf8mb4 charset, because InnoDB indexes are capped at 767 bytes,
and unfortunately: 4 * 255 = 1020 bytes.

For reference, here is the error with utf8mb4 charset:
> SQLSTATE[42000]: Syntax error or access violation: 1071 Specified key
> was too long; max key length is 767 bytes

Fixes #384 and #388.