### PR TITLE
Document master and v1 branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 
 [![Build Status](https://travis-ci.org/KnpLabs/DoctrineBehaviors.svg?branch=master)](http://travis-ci.org/KnpLabs/DoctrineBehaviors)
 
+* Branch `master` contains the next v2.0
+* Branch `v1` contains the current v1.x
 
-This PHP `>=5.4` library is a collection of traits and interfaces
+This PHP `>=7.0` library is a collection of traits and interfaces
 that add behaviors to Doctrine2 entities and repositories.
 
 It currently handles:


### PR DESCRIPTION
IMHO we need to prepare a `v2` for upcoming changes breaking BC (for instance #241).

I didn't create `v1` branch so far, I'd like some feedback first. I think we need to either:
* Create a `v2` branch, keep v1 on `master` for now and put v2 on `master` later, when it got released ;
* Or create `v1` right now and put `v2` on master, but we have to change the base branch of every current PR.

@nicolasmure @Soullivaneuh WDYT?