### PR TITLE
Only set locales on entities managed by knp translations

### DIFF
--- a/src/ORM/Translatable/TranslatableSubscriber.php
+++ b/src/ORM/Translatable/TranslatableSubscriber.php
@@ -316,7 +316,7 @@ class TranslatableSubscriber extends AbstractSubscriber
         $entity        = $eventArgs->getEntity();
         $classMetadata = $em->getClassMetadata(get_class($entity));
 
-        if (!$this->getClassAnalyzer()->hasMethod($classMetadata->reflClass, 'setCurrentLocale')) {
+        if (!$this->isTranslatable($classMetadata)) {
             return;
         }
 


### PR DESCRIPTION
There are cases where you could have a entity with the setCurrentLocale method, but that is not a translatable entity managed by KNP.

This PR only sets the default and current locales on entities that are translatable instead of relying on a method existance.

Closes https://github.com/KnpLabs/DoctrineBehaviors/issues/314
Closes https://github.com/KnpLabs/DoctrineBehaviors/pull/315

It also fixes compatibility with Sylius, because it uses its own translations implementation, and it is incompatible with having this other bundle installed.