### PR TITLE
Limit length of translation.locale to 5

### DIFF
--- a/src/ORM/Translatable/TranslatableSubscriber.php
+++ b/src/ORM/Translatable/TranslatableSubscriber.php
@@ -239,7 +239,8 @@ class TranslatableSubscriber extends AbstractSubscriber
         if (!($classMetadata->hasField('locale') || $classMetadata->hasAssociation('locale'))) {
             $classMetadata->mapField(array(
                 'fieldName' => 'locale',
-                'type'      => 'string'
+                'type'      => 'string',
+                'length'    => 5
             ));
         }
 


### PR DESCRIPTION
Limit to avoid "Specified key was too long; max key length is 767 bytes" error in MySQL <= 5.7

Fixes #384 and #388.

Improve https://github.com/KnpLabs/DoctrineBehaviors/pull/389