### PR TITLE
[Translatable] avoids empty translations to be persisted

### DIFF
--- a/src/Model/Translatable/TranslatableMethods.php
+++ b/src/Model/Translatable/TranslatableMethods.php
@@ -135,6 +135,12 @@ trait TranslatableMethods
                 $this->getNewTranslations()->removeElement($newTranslation);
             }
         }
+
+        foreach ($this->getTranslations() as $translation){
+            if($translation->isEmpty()){
+                $this->removeTranslation($translation);
+            }
+        }
     }
 
     /**

--- a/tests/Knp/DoctrineBehaviors/ORM/EntityManagerProvider.php
+++ b/tests/Knp/DoctrineBehaviors/ORM/EntityManagerProvider.php
@@ -102,7 +102,7 @@ trait EntityManagerProvider
         $mockMethods = array();
 
         foreach ($methods as $method) {
-            if (!in_array($method->name, ['addFilter', 'getFilterClassName', 'addCustomNumericFunction', 'getCustomNumericFunction'])) {
+            if (!in_array($method->name, ['addFilter', 'getFilterClassName', 'addCustomNumericFunction', 'getCustomNumericFunction', 'setSchemaAssetsFilter', 'getSchemaAssetsFilter'])) {
                 $mockMethods[] = $method->name;
             }
         }

--- a/tests/Knp/DoctrineBehaviors/ORM/TranslatableTest.php
+++ b/tests/Knp/DoctrineBehaviors/ORM/TranslatableTest.php
@@ -80,6 +80,83 @@ class TranslatableTest extends \PHPUnit_Framework_TestCase
             'удивительный',
             $entity->translate('ru')->getTitle()
         );
+
+        return $entity;
+    }
+
+    /**
+     * @test
+     */
+    public function should_not_persist_new_empty_translations()
+    {
+        $em = $this->getEntityManager();
+
+        $entity = new \BehaviorFixtures\ORM\TranslatableEntity();
+        $entity->translate('fr')->setTitle('fabuleux');
+        $entity->translate('en')->setTitle('');
+        $entity->translate('ru')->setTitle('удивительный');
+        $entity->mergeNewTranslations();
+
+        $em->persist($entity);
+        $em->flush();
+        $id = $entity->getId();
+        $em->clear();
+
+        $entity = $em
+            ->getRepository('BehaviorFixtures\ORM\TranslatableEntity')
+            ->find($id)
+        ;
+
+        $this->assertEquals(
+            'fabuleux',
+            $entity->translate('fr')->getTitle()
+        );
+
+        $this->assertNull(
+            $entity->translate('en')->getTitle()
+        );
+
+        $this->assertEquals(
+            'удивительный',
+            $entity->translate('ru')->getTitle()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function should_remove_translations_which_become_empty()
+    {
+        $entity = $this->should_persist_translations();
+
+        $em = $this->getEntityManager();
+
+        $entity->translate('en')->setTitle('');
+        $entity->mergeNewTranslations();
+
+        $em->persist($entity);
+        $em->flush();
+        $id = $entity->getId();
+        $em->clear();
+
+        $entity = $em
+            ->getRepository('BehaviorFixtures\ORM\TranslatableEntity')
+            ->find($id)
+        ;
+
+        $this->assertEquals(
+            'fabuleux',
+            $entity->translate('fr')->getTitle()
+        );
+
+        $this->assertNull(
+            $entity->translate('en')->getTitle()
+        );
+
+        $this->assertEquals(
+            'удивительный',
+            $entity->translate('ru')->getTitle()
+        );
     }
 
     /**


### PR DESCRIPTION
When an empty translation is persisted, trying to update that translation afterwards with some content blows up a unique constraint violation. This is because current code doesn't return old empty translation (because it checks if it's empty inside "doTranslate" method), making new content to be interpreted like a brand new translation.

Currently, new empty translations are discarded properly, but updating a previous persisted translations can lead to a persisted empty translation, which produces the same effect as persisting brand new empty translations.

So, this change avoids any empty translation to be persisted in any case, fixing the constraint issue. 