### PR TITLE
Fix config deprecation

### DIFF
--- a/src/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bundle/DependencyInjection/Configuration.php
@@ -9,9 +9,9 @@ class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder()
     {
-        $builder = new TreeBuilder();
+        $builder = new TreeBuilder('knp_doctrine_behaviors');
         $builder
-            ->root('knp_doctrine_behaviors')
+            ->getRootNode()
             ->beforeNormalization()
                 ->always(function (array $config) {
                     if (empty($config)) {

--- a/src/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bundle/DependencyInjection/Configuration.php
@@ -10,8 +10,15 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $builder = new TreeBuilder('knp_doctrine_behaviors');
-        $builder
-            ->getRootNode()
+
+        if (method_exists($builder, 'getRootNode')) {
+            $rootNode = $builder->getRootNode();
+        } else {
+            // for symfony/config 4.1 and older
+            $rootNode = $builder->root('knp_doctrine_behaviors');
+        }
+
+        $rootNode
             ->beforeNormalization()
                 ->always(function (array $config) {
                     if (empty($config)) {


### PR DESCRIPTION
A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0

#408 There is one opened issue about it. 