### PR TITLE
[Translatable] make recursive mode configurable

### DIFF
--- a/config/orm-services.yml
+++ b/config/orm-services.yml
@@ -8,6 +8,7 @@ parameters:
     knp.doctrine_behaviors.translatable_subscriber.translation_trait: Knp\DoctrineBehaviors\Model\Translatable\Translation
     knp.doctrine_behaviors.translatable_subscriber.translatable_fetch_method: LAZY
     knp.doctrine_behaviors.translatable_subscriber.translation_fetch_method: LAZY
+    knp.doctrine_behaviors.translatable_subscriber.is_recursive: false
     knp.doctrine_behaviors.softdeletable_subscriber.class: Knp\DoctrineBehaviors\ORM\SoftDeletable\SoftDeletableSubscriber
     knp.doctrine_behaviors.softdeletable_subscriber.softdeletable_trait: Knp\DoctrineBehaviors\Model\SoftDeletable\SoftDeletable
     knp.doctrine_behaviors.timestampable_subscriber.class: Knp\DoctrineBehaviors\ORM\Timestampable\TimestampableSubscriber
@@ -44,6 +45,7 @@ services:
             - "%knp.doctrine_behaviors.translatable_subscriber.translation_trait%"
             - "%knp.doctrine_behaviors.translatable_subscriber.translatable_fetch_method%"
             - "%knp.doctrine_behaviors.translatable_subscriber.translation_fetch_method%"
+            - "%knp.doctrine_behaviors.translatable_subscriber.is_recursive%"
         tags:
             - { name: doctrine.event_subscriber }
 

--- a/src/ORM/Translatable/TranslatableSubscriber.php
+++ b/src/ORM/Translatable/TranslatableSubscriber.php
@@ -43,9 +43,9 @@ class TranslatableSubscriber extends AbstractSubscriber
 
     public function __construct(ClassAnalyzer $classAnalyzer, callable $currentLocaleCallable = null,
                                 callable $defaultLocaleCallable = null,$translatableTrait, $translationTrait,
-                                $translatableFetchMode, $translationFetchMode)
+                                $translatableFetchMode, $translationFetchMode, $isRecursive = false)
     {
-        parent::__construct($classAnalyzer, false);
+        parent::__construct($classAnalyzer, $isRecursive);
 
         $this->currentLocaleCallable = $currentLocaleCallable;
         $this->defaultLocaleCallable = $defaultLocaleCallable;
@@ -285,7 +285,7 @@ class TranslatableSubscriber extends AbstractSubscriber
      */
     private function isTranslatable(ClassMetadata $classMetadata)
     {
-        return $this->getClassAnalyzer()->hasTrait($classMetadata->reflClass, $this->translatableTrait);
+        return $this->getClassAnalyzer()->hasTrait($classMetadata->reflClass, $this->translatableTrait, $this->isRecursive);
     }
 
     /**
@@ -297,7 +297,7 @@ class TranslatableSubscriber extends AbstractSubscriber
      */
     private function isTranslation(ClassMetadata $classMetadata)
     {
-        return $this->getClassAnalyzer()->hasTrait($classMetadata->reflClass, $this->translationTrait);
+        return $this->getClassAnalyzer()->hasTrait($classMetadata->reflClass, $this->translationTrait, $this->isRecursive);
     }
 
     public function postLoad(LifecycleEventArgs $eventArgs)


### PR DESCRIPTION
When Translatable used in combination with inheritance map (in my specific case I'm using Single Table Inheritance), it does not work as expected for mapped entities (I got `null` istead of translations, because `TranslatableSubscriber::postLoad()` never called, and thus correct locale is not set).
 
I found the reason is that `TranslatableSubscriber::isTranslatable()` check returns false for mapped entities. It can be easily fixed by passing `$isRecursive` parameter as `true` to `ClassAnalyzer::hasTrait()`.

Proposed change in this PR will make `$isRecursive` of `TranlatableSubscriber` configurable.

I checked it in my project, and when proposed changes applied and in app config I set
```
parameters:
    knp.doctrine_behaviors.translatable_subscriber.is_recursive: true
```

translations works for mapped entities as expected.
