### PR TITLE
Fix for TreeBuilder E_USER_DEPRECATED message

### DIFF
--- a/src/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bundle/DependencyInjection/Configuration.php
@@ -9,9 +9,9 @@ class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder()
     {
-        $builder = new TreeBuilder();
+        $builder = new TreeBuilder('knp_doctrine_behaviors');
         $builder
-            ->root('knp_doctrine_behaviors')
+            ->getRootNode()
             ->beforeNormalization()
                 ->always(function (array $config) {
                     if (empty($config)) {


### PR DESCRIPTION
In /vendor/symfony/config/Definition/Builder/TreeBuilder.php:30
"A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0."
Tested, works.