### PR TITLE
Drop id property from translation trait

### DIFF
--- a/src/Model/Translatable/TranslationMethods.php
+++ b/src/Model/Translatable/TranslationMethods.php
@@ -30,15 +30,6 @@ trait TranslationMethods
     }
 
     /**
-     * Returns object id.
-     *
-     * @return mixed
-     */
-    public function getId() {
-        return $this->id;
-    }
-
-    /**
      * Sets entity, that this translation should be mapped to.
      *
      * @param Translatable $translatable The translatable

--- a/src/Model/Translatable/TranslationProperties.php
+++ b/src/Model/Translatable/TranslationProperties.php
@@ -19,11 +19,6 @@ namespace Knp\DoctrineBehaviors\Model\Translatable;
 trait TranslationProperties
 {
     /**
-     * @var int
-     */
-    protected $id;
-
-    /**
      * @var string
      */
     protected $locale;


### PR DESCRIPTION
Dropped $id property from translation trait.

Any doctrine entity is shipped with its own $id property. Also, without the $id record inside the trait it is a little bit easier to deal with generated code like symfonys maker bundle or doctrine generator. 

Maybe for BC issues, an integration of mapId() is helpful:

https://github.com/KnpLabs/DoctrineBehaviors/blob/9bc5a6a6a6e6cb92ac7467410876882994732325/src/ORM/Translatable/TranslatableSubscriber.php#L93 