### PR TITLE
Update Configuration.php

### DIFF
--- a/src/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bundle/DependencyInjection/Configuration.php
@@ -9,9 +9,9 @@ class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder()
     {
-        $builder = new TreeBuilder();
+        $builder = new TreeBuilder('knp_doctrine_behaviors');
         $builder
-            ->root('knp_doctrine_behaviors')
+            ->getRootNode()
             ->beforeNormalization()
                 ->always(function (array $config) {
                     if (empty($config)) {


### PR DESCRIPTION
In the 4.2 Symfony version the constructor of TreeBuilder requires to enter the name parameter.
After this modify I resolve the error  ArgumentCountError:
Too few arguments to function Symfony\Component\Config\Definition\Builder\TreeBuilder::__construct(), 0