### PR TITLE
[WIP] Allo repository as a service

### DIFF
--- a/src/Contract/Repository/QueryBuilderAwareRepositoryInterface.php
+++ b/src/Contract/Repository/QueryBuilderAwareRepositoryInterface.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Knp\DoctrineBehaviors\Contract\Repository;
+
+use Doctrine\ORM\QueryBuilder;
+
+interface QueryBuilderAwareRepositoryInterface
+{
+    /**
+     * @param string $alias
+     * @param string|null $indexBy
+     */
+    public function createQueryBuilder($alias, $indexBy = null): QueryBuilder;
+}

--- a/src/Contract/Repository/QueryBuilderAwareRepositoryInterface.php
+++ b/src/Contract/Repository/QueryBuilderAwareRepositoryInterface.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Knp\DoctrineBehaviors\Contract\Repository;
 


### PR DESCRIPTION
Now only pure children of `EntityRepository` are supported, which is cruel vendor lock for such a simple features.

This PR should allow other repositories to use it:
https://www.tomasvotruba.cz/blog/2017/10/16/how-to-use-repository-with-doctrine-as-service-in-symfony/