### PR TITLE
Fix slug generation if the getRegenerateSlugOnUpdate method return false

### DIFF
--- a/ecs.yaml
+++ b/ecs.yaml
@@ -31,6 +31,9 @@ parameters:
             # & bug
             - "*Repository.php"
 
+        SlevomatCodingStandard\Sniffs\Classes\UnusedPrivateElementsSniff:
+            - "tests/Fixtures/Entity/SluggableWithoutRegenerateEntity.php"
+
 services:
     Symplify\CodingStandard\Sniffs\CleanCode\CognitiveComplexitySniff:
         max_cognitive_complexity: 8

--- a/src/Model/Sluggable/SluggableMethodsTrait.php
+++ b/src/Model/Sluggable/SluggableMethodsTrait.php
@@ -29,7 +29,7 @@ trait SluggableMethodsTrait
      */
     public function generateSlug(): void
     {
-        if (! $this->getRegenerateSlugOnUpdate()) {
+        if (null !== $this->slug && false === $this->getRegenerateSlugOnUpdate()) {
             return;
         }
 

--- a/src/Model/Sluggable/SluggableMethodsTrait.php
+++ b/src/Model/Sluggable/SluggableMethodsTrait.php
@@ -29,7 +29,7 @@ trait SluggableMethodsTrait
      */
     public function generateSlug(): void
     {
-        if (null !== $this->slug && false === $this->getRegenerateSlugOnUpdate()) {
+        if ($this->slug !== null && $this->getRegenerateSlugOnUpdate() === false) {
             return;
         }
 

--- a/tests/Fixtures/Entity/SluggableWithoutRegenerateEntity.php
+++ b/tests/Fixtures/Entity/SluggableWithoutRegenerateEntity.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Knp\DoctrineBehaviors\Tests\Fixtures\Entity;
 
-use DateTime;
-use DateTimeInterface;
 use Doctrine\ORM\Mapping as ORM;
 use Knp\DoctrineBehaviors\Contract\Entity\SluggableInterface;
 use Knp\DoctrineBehaviors\Model\Sluggable\SluggableTrait;

--- a/tests/Fixtures/Entity/SluggableWithoutRegenerateEntity.php
+++ b/tests/Fixtures/Entity/SluggableWithoutRegenerateEntity.php
@@ -31,17 +31,6 @@ class SluggableWithoutRegenerateEntity implements SluggableInterface
      */
     private $id;
 
-    /**
-     * @ORM\Column(type="datetime")
-     * @var DateTimeInterface
-     */
-    private $date;
-
-    public function __construct()
-    {
-        $this->date = (new DateTime())->modify('-1 year');
-    }
-
     public function getId(): int
     {
         return $this->id;
@@ -55,16 +44,6 @@ class SluggableWithoutRegenerateEntity implements SluggableInterface
     public function setName(string $name): void
     {
         $this->name = $name;
-    }
-
-    public function getDate(): DateTimeInterface
-    {
-        return $this->date;
-    }
-
-    public function setDate(DateTimeInterface $date): void
-    {
-        $this->date = $date;
     }
 
     /**

--- a/tests/Fixtures/Entity/SluggableWithoutRegenerateEntity.php
+++ b/tests/Fixtures/Entity/SluggableWithoutRegenerateEntity.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Knp\DoctrineBehaviors\Tests\Fixtures\Entity;
+
+use DateTime;
+use DateTimeInterface;
+use Doctrine\ORM\Mapping as ORM;
+use Knp\DoctrineBehaviors\Contract\Entity\SluggableInterface;
+use Knp\DoctrineBehaviors\Model\Sluggable\SluggableTrait;
+
+/**
+ * @ORM\Entity
+ */
+class SluggableWithoutRegenerateEntity implements SluggableInterface
+{
+    use SluggableTrait;
+
+    /**
+     * @ORM\Column(type="string")
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     * @var int
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(type="datetime")
+     * @var DateTimeInterface
+     */
+    private $date;
+
+    public function __construct()
+    {
+        $this->date = (new DateTime())->modify('-1 year');
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function getDate(): DateTimeInterface
+    {
+        return $this->date;
+    }
+
+    public function setDate(DateTimeInterface $date): void
+    {
+        $this->date = $date;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getSluggableFields(): array
+    {
+        return ['name'];
+    }
+
+    private function getRegenerateSlugOnUpdate(): bool
+    {
+        return false;
+    }
+}

--- a/tests/ORM/SluggableWithoutRegenerateTest.php
+++ b/tests/ORM/SluggableWithoutRegenerateTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Knp\DoctrineBehaviors\Tests\ORM;
+
+use DateTime;
+use Doctrine\Common\Persistence\ObjectRepository;
+use Doctrine\ORM\EntityRepository;
+use Iterator;
+use Knp\DoctrineBehaviors\Tests\AbstractBehaviorTestCase;
+use Knp\DoctrineBehaviors\Tests\Fixtures\Entity\SluggableEntity;
+use Knp\DoctrineBehaviors\Tests\Fixtures\Entity\SluggableWithoutRegenerateEntity;
+
+final class SluggableWithoutRegenerateTest extends AbstractBehaviorTestCase
+{
+    /**
+     * @var ObjectRepository|EntityRepository
+     */
+    private $sluggableWithoutRegenerateRepository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->sluggableWithoutRegenerateRepository = $this->entityManager->getRepository(SluggableWithoutRegenerateEntity::class);
+    }
+
+    public function testSlugLoading(): void
+    {
+        $entity = new SluggableWithoutRegenerateEntity();
+        $entity->setName('The name');
+
+        $this->entityManager->persist($entity);
+        $this->entityManager->flush();
+
+        $id = $entity->getId();
+        $this->assertNotNull($id);
+
+        $this->entityManager->clear();
+
+        /** @var SluggableEntity $entity */
+        $entity = $this->sluggableWithoutRegenerateRepository->find($id);
+
+        $this->assertNotNull($entity);
+        $this->assertSame('the-name', $entity->getSlug());
+    }
+
+    public function testNotUpdatedSlug(): void
+    {
+        $entity = new SluggableWithoutRegenerateEntity();
+        $entity->setName('The name');
+
+        $this->entityManager->persist($entity);
+        $this->entityManager->flush();
+
+        $this->assertSame('the-name', $entity->getSlug());
+
+        $entity->setName('The name 2');
+
+        $this->entityManager->persist($entity);
+        $this->entityManager->flush();
+
+        $this->assertSame('the-name', $entity->getSlug());
+    }
+}

--- a/tests/ORM/SluggableWithoutRegenerateTest.php
+++ b/tests/ORM/SluggableWithoutRegenerateTest.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace Knp\DoctrineBehaviors\Tests\ORM;
 
-use DateTime;
 use Doctrine\Common\Persistence\ObjectRepository;
 use Doctrine\ORM\EntityRepository;
-use Iterator;
 use Knp\DoctrineBehaviors\Tests\AbstractBehaviorTestCase;
 use Knp\DoctrineBehaviors\Tests\Fixtures\Entity\SluggableEntity;
 use Knp\DoctrineBehaviors\Tests\Fixtures\Entity\SluggableWithoutRegenerateEntity;
@@ -23,7 +21,9 @@ final class SluggableWithoutRegenerateTest extends AbstractBehaviorTestCase
     {
         parent::setUp();
 
-        $this->sluggableWithoutRegenerateRepository = $this->entityManager->getRepository(SluggableWithoutRegenerateEntity::class);
+        $this->sluggableWithoutRegenerateRepository = $this->entityManager->getRepository(
+            SluggableWithoutRegenerateEntity::class
+        );
     }
 
     public function testSlugLoading(): void


### PR DESCRIPTION
This PR aims to fix the bug described in the issue #471 

If the getRegenerateSlugOnUpdate  method return false, the slug will be generate if its value is null. 

This behavior seems legit because you can set the slug manually and it won't be regenerated. However if you set manually the slug value to null, it will be regenerated (the setter doesn't allow this anyway).