### PR TITLE
[Blameable] Added new parameter to allow definition of the user entity

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -1,6 +1,7 @@
 parameters:
     doctrine_behaviors_translatable_fetch_mode: "LAZY"
     doctrine_behaviors_translation_fetch_mode: "LAZY"
+    doctrine_behaviors_blameable_user_entity: ~
 
 services:
     _defaults:
@@ -10,6 +11,7 @@ services:
         bind:
             $translatableFetchMode: "%doctrine_behaviors_translatable_fetch_mode%"
             $translationFetchMode: "%doctrine_behaviors_translation_fetch_mode%"
+            $blameableUserEntity: "%doctrine_behaviors_blameable_user_entity%"
 
     Knp\DoctrineBehaviors\:
         resource: "../src"

--- a/docs/blameable.md
+++ b/docs/blameable.md
@@ -48,3 +48,13 @@ $updatedBy = $category->getUpdatedBy();
 var_dump($updatedBy);
 // "App\Entity\User" object
 ```
+
+## Configuration
+
+By default, no user entity is provided. You need to specify the User class with a new parameter in your config:
+
+```yaml
+# services.yaml
+parameters:
+    doctrine_behaviors_blameable_user_entity: App\Entity\User
+```

--- a/src/Provider/UserProvider.php
+++ b/src/Provider/UserProvider.php
@@ -10,20 +10,33 @@ use Symfony\Component\Security\Core\Security;
 final class UserProvider implements UserProviderInterface
 {
     /**
+     * @var string|null
+     */
+    private $blameableUserEntity;
+
+    /**
      * @var Security
      */
     private $security;
 
-    public function __construct(Security $security)
+    public function __construct(Security $security, ?string $blameableUserEntity = null)
     {
         $this->security = $security;
+        $this->blameableUserEntity = $blameableUserEntity;
     }
 
     public function provideUser()
     {
         $token = $this->security->getToken();
-        if ($token !== null) {
-            return $token->getUser();
+        if ($token) {
+            $user = $token->getUser();
+            if ($this->blameableUserEntity) {
+                if ($user instanceof $this->blameableUserEntity) {
+                    return $user;
+                }
+            } else {
+                return $user;
+            }
         }
 
         return null;

--- a/tests/Fixtures/Entity/BlameableEntityWithUserEntity.php
+++ b/tests/Fixtures/Entity/BlameableEntityWithUserEntity.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Knp\DoctrineBehaviors\Tests\Fixtures\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Knp\DoctrineBehaviors\Contract\Entity\BlameableInterface;
+use Knp\DoctrineBehaviors\Model\Blameable\BlameableTrait;
+
+/**
+ * @ORM\Entity
+ */
+class BlameableEntityWithUserEntity implements BlameableInterface
+{
+    use BlameableTrait;
+
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     * @var int
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(type="string", nullable=true)
+     * @var string
+     */
+    private $title;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+}

--- a/tests/Provider/EntityUserProvider.php
+++ b/tests/Provider/EntityUserProvider.php
@@ -16,6 +16,11 @@ final class EntityUserProvider implements UserProviderInterface
     private $isUserEntityPrepared = false;
 
     /**
+     * @var UserEntity[]
+     */
+    private $userEntities = [];
+
+    /**
      * @var UserEntity
      */
     private $userEntity;
@@ -30,9 +35,16 @@ final class EntityUserProvider implements UserProviderInterface
         $this->entityManager = $entityManager;
     }
 
+    public function changeUser($userEntity): void
+    {
+        if (! empty($this->userEntities) && array_key_exists($userEntity, $this->userEntities)) {
+            $this->userEntity = $this->userEntities[$userEntity];
+        }
+    }
+
     public function provideUser()
     {
-        $this->prepareUserEntity();
+        $this->prepareUserEntities();
 
         return $this->userEntity;
     }
@@ -42,18 +54,25 @@ final class EntityUserProvider implements UserProviderInterface
         return UserEntity::class;
     }
 
-    private function prepareUserEntity(): void
+    private function prepareUserEntities(): void
     {
         if ($this->isUserEntityPrepared) {
             return;
         }
 
         $userEntity = new UserEntity();
-        $userEntity->setUsername('some_user_name');
+        $userEntity->setUsername('user');
+
+        $user2Entity = new UserEntity();
+        $user2Entity->setUsername('user2');
 
         // persist user
         $this->entityManager->persist($userEntity);
+        $this->entityManager->persist($user2Entity);
         $this->entityManager->flush();
+
+        $this->userEntities['user'] = $userEntity;
+        $this->userEntities['user2'] = $user2Entity;
 
         $this->userEntity = $userEntity;
 

--- a/tests/config/config_test_with_blameable_entity.yaml
+++ b/tests/config/config_test_with_blameable_entity.yaml
@@ -1,3 +1,6 @@
+parameters:
+    doctrine_behaviors_blameable_user_entity: Knp\DoctrineBehaviors\Tests\Fixtures\Entity\UserEntity
+
 services:
     _defaults:
         public: true


### PR DESCRIPTION
Closes #486 

I can't find a way to get the user in the security provider. In order to make Blameable works well, a added the parameter `doctrine_behaviors_blameable_user_entity` which allows the user to define the entity to use