### PR TITLE
Moved unitOfWork access to methods instead of constructor

### DIFF
--- a/src/EventSubscriber/BlameableSubscriber.php
+++ b/src/EventSubscriber/BlameableSubscriber.php
@@ -10,7 +10,6 @@ use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
-use Doctrine\ORM\UnitOfWork;
 use Knp\DoctrineBehaviors\Contract\Entity\BlameableInterface;
 use Knp\DoctrineBehaviors\Contract\Provider\UserProviderInterface;
 
@@ -37,14 +36,14 @@ final class BlameableSubscriber implements EventSubscriber
     private $userProvider;
 
     /**
-     * @var UnitOfWork
+     * @var EntityManagerInterface
      */
-    private $unitOfWork;
+    private $entityManager;
 
     public function __construct(UserProviderInterface $userProvider, EntityManagerInterface $entityManager)
     {
         $this->userProvider = $userProvider;
-        $this->unitOfWork = $entityManager->getUnitOfWork();
+        $this->entityManager = $entityManager;
     }
 
     /**
@@ -80,13 +79,13 @@ final class BlameableSubscriber implements EventSubscriber
         if (! $entity->getCreatedBy()) {
             $entity->setCreatedBy($user);
 
-            $this->unitOfWork->propertyChanged($entity, self::CREATED_BY, null, $user);
+            $this->entityManager->getUnitOfWork()->propertyChanged($entity, self::CREATED_BY, null, $user);
         }
 
         if (! $entity->getUpdatedBy()) {
             $entity->setUpdatedBy($user);
 
-            $this->unitOfWork->propertyChanged($entity, self::UPDATED_BY, null, $user);
+            $this->entityManager->getUnitOfWork()->propertyChanged($entity, self::UPDATED_BY, null, $user);
         }
     }
 
@@ -108,7 +107,7 @@ final class BlameableSubscriber implements EventSubscriber
         $oldValue = $entity->getUpdatedBy();
         $entity->setUpdatedBy($user);
 
-        $this->unitOfWork->propertyChanged($entity, self::UPDATED_BY, $oldValue, $user);
+        $this->entityManager->getUnitOfWork()->propertyChanged($entity, self::UPDATED_BY, $oldValue, $user);
     }
 
     /**
@@ -129,7 +128,7 @@ final class BlameableSubscriber implements EventSubscriber
         $oldValue = $entity->getDeletedBy();
         $entity->setDeletedBy($user);
 
-        $this->unitOfWork->propertyChanged($entity, self::DELETED_BY, $oldValue, $user);
+        $this->entityManager->getUnitOfWork()->propertyChanged($entity, self::DELETED_BY, $oldValue, $user);
     }
 
     public function getSubscribedEvents()

--- a/src/EventSubscriber/BlameableSubscriber.php
+++ b/src/EventSubscriber/BlameableSubscriber.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\UnitOfWork;
 use Knp\DoctrineBehaviors\Contract\Entity\BlameableInterface;
 use Knp\DoctrineBehaviors\Contract\Provider\UserProviderInterface;
 
@@ -79,13 +80,13 @@ final class BlameableSubscriber implements EventSubscriber
         if (! $entity->getCreatedBy()) {
             $entity->setCreatedBy($user);
 
-            $this->entityManager->getUnitOfWork()->propertyChanged($entity, self::CREATED_BY, null, $user);
+            $this->getUnitOfWork()->propertyChanged($entity, self::CREATED_BY, null, $user);
         }
 
         if (! $entity->getUpdatedBy()) {
             $entity->setUpdatedBy($user);
 
-            $this->entityManager->getUnitOfWork()->propertyChanged($entity, self::UPDATED_BY, null, $user);
+            $this->getUnitOfWork()->propertyChanged($entity, self::UPDATED_BY, null, $user);
         }
     }
 
@@ -107,7 +108,7 @@ final class BlameableSubscriber implements EventSubscriber
         $oldValue = $entity->getUpdatedBy();
         $entity->setUpdatedBy($user);
 
-        $this->entityManager->getUnitOfWork()->propertyChanged($entity, self::UPDATED_BY, $oldValue, $user);
+        $this->getUnitOfWork()->propertyChanged($entity, self::UPDATED_BY, $oldValue, $user);
     }
 
     /**
@@ -128,7 +129,7 @@ final class BlameableSubscriber implements EventSubscriber
         $oldValue = $entity->getDeletedBy();
         $entity->setDeletedBy($user);
 
-        $this->entityManager->getUnitOfWork()->propertyChanged($entity, self::DELETED_BY, $oldValue, $user);
+        $this->getUnitOfWork()->propertyChanged($entity, self::DELETED_BY, $oldValue, $user);
     }
 
     public function getSubscribedEvents()
@@ -195,5 +196,10 @@ final class BlameableSubscriber implements EventSubscriber
             'type' => 'string',
             'nullable' => true,
         ]);
+    }
+
+    private function getUnitOfWork() : UnitOfWork
+    {
+        return $this->entityManager->getUnitOfWork();
     }
 }


### PR DESCRIPTION
Fixes https://github.com/KnpLabs/DoctrineBehaviors/issues/492

For me this fixes a loop which made PHP crash. I am not sure why this happened but moving the unitOfWork access to the functions would make sense anyway.