### PR TITLE
Add another layer for locale fallback - %locale% parameter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "symfony/dependency-injection": "^4.4|^5.0",
         "symfony/http-kernel": "^4.4|^5.0",
         "symfony/security-core": "^4.4|^5.0",
+        "symfony/framework-bundle": "^4.4|^5.0",
         "symfony/string": "^5.0",
         "symplify/package-builder": "^7.2",
         "nette/utils": "^3.0",

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -12,7 +12,6 @@ services:
             $translatableFetchMode: "%doctrine_behaviors_translatable_fetch_mode%"
             $translationFetchMode: "%doctrine_behaviors_translation_fetch_mode%"
             $blameableUserEntity: "%doctrine_behaviors_blameable_user_entity%"
-            string $defaultLocale: "%locale%"
 
     Knp\DoctrineBehaviors\:
         resource: "../src"

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -12,6 +12,7 @@ services:
             $translatableFetchMode: "%doctrine_behaviors_translatable_fetch_mode%"
             $translationFetchMode: "%doctrine_behaviors_translation_fetch_mode%"
             $blameableUserEntity: "%doctrine_behaviors_blameable_user_entity%"
+            string $defaultLocale: "%locale%"
 
     Knp\DoctrineBehaviors\:
         resource: "../src"

--- a/src/Provider/LocaleProvider.php
+++ b/src/Provider/LocaleProvider.php
@@ -54,6 +54,11 @@ final class LocaleProvider implements LocaleProviderInterface
 
     public function provideFallbackLocale(): ?string
     {
+        $currentRequest = $this->requestStack->getCurrentRequest();
+        if ($currentRequest !== null) {
+            return $this->getDefaultLocale();
+        }
+
         return $this->defaultLocale;
     }
 }

--- a/src/Provider/LocaleProvider.php
+++ b/src/Provider/LocaleProvider.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Knp\DoctrineBehaviors\Provider;
 
 use Knp\DoctrineBehaviors\Contract\Provider\LocaleProviderInterface;
+use Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Contracts\Translation\LocaleAwareInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -17,20 +19,23 @@ final class LocaleProvider implements LocaleProviderInterface
     private $translator;
 
     /**
-     * @var string|null
+     * @var ParameterBagInterface
      */
-    private $defaultLocale;
+    private $parameterBag;
 
     /**
      * @var RequestStack
      */
     private $requestStack;
 
-    public function __construct(RequestStack $requestStack, string $defaultLocale, ?TranslatorInterface $translator)
-    {
+    public function __construct(
+        RequestStack $requestStack,
+        ParameterBagInterface $parameterBag,
+        ?TranslatorInterface $translator
+    ) {
         $this->requestStack = $requestStack;
-        $this->defaultLocale = $defaultLocale;
         $this->translator = $translator;
+        $this->parameterBag = $parameterBag;
     }
 
     public function provideCurrentLocale(): ?string
@@ -59,6 +64,10 @@ final class LocaleProvider implements LocaleProviderInterface
             return $this->getDefaultLocale();
         }
 
-        return $this->defaultLocale;
+        try {
+            return $this->parameterBag->get('locale');
+        } catch (ParameterNotFoundException $parameterNotFoundException) {
+            return null;
+        }
     }
 }

--- a/src/Provider/LocaleProvider.php
+++ b/src/Provider/LocaleProvider.php
@@ -17,13 +17,19 @@ final class LocaleProvider implements LocaleProviderInterface
     private $translator;
 
     /**
+     * @var string|null
+     */
+    private $defaultLocale;
+
+    /**
      * @var RequestStack
      */
     private $requestStack;
 
-    public function __construct(RequestStack $requestStack, ?TranslatorInterface $translator)
+    public function __construct(RequestStack $requestStack, string $defaultLocale, ?TranslatorInterface $translator)
     {
         $this->requestStack = $requestStack;
+        $this->defaultLocale = $defaultLocale;
         $this->translator = $translator;
     }
 
@@ -39,30 +45,15 @@ final class LocaleProvider implements LocaleProviderInterface
             return $currentLocale;
         }
 
-        return $this->getTranslatorLocale();
-    }
-
-    public function provideFallbackLocale(): ?string
-    {
-        $currentRequest = $this->requestStack->getCurrentRequest();
-        if ($currentRequest === null) {
-            return null;
-        }
-
-        $defaultLocale = $currentRequest->getDefaultLocale();
-        if ($defaultLocale) {
-            return $defaultLocale;
-        }
-
-        return $this->getTranslatorLocale();
-    }
-
-    private function getTranslatorLocale(): ?string
-    {
         if ($this->translator) {
             return $this->translator->getLocale();
         }
 
         return null;
+    }
+
+    public function provideFallbackLocale(): ?string
+    {
+        return $this->defaultLocale;
     }
 }

--- a/tests/config/config_test.yaml
+++ b/tests/config/config_test.yaml
@@ -6,6 +6,7 @@ parameters:
     env(DB_PASSWD): ""
     env(DB_MEMORY): "true"
     kernel.secret: "for_framework_bundle"
+    locale: "en"
 
 services:
     _defaults:


### PR DESCRIPTION
In the versions <2 the `%locale%` parameter was used as the fallback locale. Now we are trying to get the `defaultLocale` from the Request which is fine IMO. But we should use the `%locale%` parameter if no reqest exists.
I am aware that the `%locale%` parameter is now mandatory again. Is this a problem? Should we switch to `%kernel.default_locale%` which would require that we require `symfony/framework` as a dependency AFAIK.

Fixing this issue is mostly important because now there is no default locale set on cli.