### PR TITLE
Merge pull request #505 from fsoedjede/488-translatable-with-sluggable

### DIFF
--- a/tests/Fixtures/Entity/SluggableTranslatableEntity.php
+++ b/tests/Fixtures/Entity/SluggableTranslatableEntity.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Knp\DoctrineBehaviors\Tests\Fixtures\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Knp\DoctrineBehaviors\Contract\Entity\TranslatableInterface;
+use Knp\DoctrineBehaviors\Model\Translatable\TranslatableTrait;
+
+/**
+ * @ORM\Entity
+ */
+class SluggableTranslatableEntity implements TranslatableInterface
+{
+    use TranslatableTrait;
+
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     * @var int
+     */
+    private $id;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+}

--- a/tests/Fixtures/Entity/SluggableTranslatableEntityTranslation.php
+++ b/tests/Fixtures/Entity/SluggableTranslatableEntityTranslation.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Knp\DoctrineBehaviors\Tests\Fixtures\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Knp\DoctrineBehaviors\Contract\Entity\SluggableInterface;
+use Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface;
+use Knp\DoctrineBehaviors\Model\Sluggable\SluggableTrait;
+use Knp\DoctrineBehaviors\Model\Translatable\TranslationTrait;
+
+/**
+ * @ORM\Entity
+ */
+class SluggableTranslatableEntityTranslation implements TranslationInterface, SluggableInterface
+{
+    use SluggableTrait;
+    use TranslationTrait;
+
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     * @var int
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(type="string")
+     * @var string|null
+     */
+    private $title;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getSluggableFields(): array
+    {
+        return ['title'];
+    }
+
+    public function shouldGenerateUniqueSlugs(): bool
+    {
+        return true;
+    }
+}

--- a/tests/ORM/SluggableWithTranslatableEntityAndUniquenessTest.php
+++ b/tests/ORM/SluggableWithTranslatableEntityAndUniquenessTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Knp\DoctrineBehaviors\Tests\ORM;
+
+use Doctrine\Common\Persistence\ObjectRepository;
+use Doctrine\ORM\EntityRepository;
+use Knp\DoctrineBehaviors\Tests\AbstractBehaviorTestCase;
+use Knp\DoctrineBehaviors\Tests\Fixtures\Entity\SluggableTranslatableEntity;
+
+final class SluggableWithTranslatableEntityAndUniquenessTest extends AbstractBehaviorTestCase
+{
+    /**
+     * @var ObjectRepository|EntityRepository
+     */
+    private $translatableRepository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->translatableRepository = $this->entityManager->getRepository(SluggableTranslatableEntity::class);
+    }
+
+    public function testSlugLoading(): void
+    {
+        $entity = new SluggableTranslatableEntity();
+        $entity->translate('fr')->setTitle('Lorem ipsum');
+        $entity->translate('en')->setTitle('Lorem ipsum');
+        $entity->mergeNewTranslations();
+
+        $this->entityManager->persist($entity);
+        $this->entityManager->flush();
+
+        $id = $entity->getId();
+        $this->assertNotNull($id);
+
+        $this->entityManager->clear();
+
+        /** @var SluggableTranslatableEntity $entity */
+        $entity = $this->translatableRepository->find($id);
+        $entityFR = $entity->translate('fr');
+        $entityEN = $entity->translate('en');
+
+        $this->assertNotNull($entity);
+        $this->assertSame('Lorem ipsum', $entityFR->getTitle());
+        $this->assertSame('lorem-ipsum', $entityFR->getSlug());
+        $this->assertSame('Lorem ipsum', $entityEN->getTitle());
+        $this->assertSame('lorem-ipsum-1', $entityEN->getSlug());
+    }
+
+    public function testNotUpdatedSlug(): void
+    {
+        $entity = new SluggableTranslatableEntity();
+        $entity->translate('fr')->setTitle('Lorem ipsum');
+        $entity->translate('en')->setTitle('Lorem ipsum');
+        $entity->mergeNewTranslations();
+
+        $this->entityManager->persist($entity);
+        $this->entityManager->flush();
+
+        $entityFR = $entity->translate('fr');
+        $entityEN = $entity->translate('en');
+
+        $this->assertSame('lorem-ipsum', $entityFR->getSlug());
+        $this->assertSame('lorem-ipsum-1', $entityEN->getSlug());
+        $entity->translate('fr')->setTitle('Mon titre');
+        $entity->translate('en')->setTitle('My title');
+
+        $this->assertSame('lorem-ipsum', $entityFR->getSlug());
+        $this->assertSame('lorem-ipsum-1', $entityEN->getSlug());
+    }
+}


### PR DESCRIPTION
Closes #488 

I use the UnitOfWork because that's the only side I could get entities which are going to be save and check if the slug does not match the current one