### PR TITLE
Allow updatedAt to be null to support legacy data

### DIFF
--- a/src/Contract/Entity/TimestampableInterface.php
+++ b/src/Contract/Entity/TimestampableInterface.php
@@ -14,7 +14,7 @@ interface TimestampableInterface
 
     public function setCreatedAt(DateTimeInterface $createdAt): void;
 
-    public function getUpdatedAt(): DateTimeInterface;
+    public function getUpdatedAt(): ?DateTimeInterface;
 
-    public function setUpdatedAt(DateTimeInterface $updatedAt): void;
+    public function setUpdatedAt(?DateTimeInterface $updatedAt): void;
 }

--- a/src/Model/Timestampable/TimestampableMethodsTrait.php
+++ b/src/Model/Timestampable/TimestampableMethodsTrait.php
@@ -16,7 +16,7 @@ trait TimestampableMethodsTrait
         return $this->createdAt;
     }
 
-    public function getUpdatedAt(): DateTimeInterface
+    public function getUpdatedAt(): ?DateTimeInterface
     {
         return $this->updatedAt;
     }
@@ -26,7 +26,7 @@ trait TimestampableMethodsTrait
         $this->createdAt = $createdAt;
     }
 
-    public function setUpdatedAt(DateTimeInterface $updatedAt): void
+    public function setUpdatedAt(?DateTimeInterface $updatedAt): void
     {
         $this->updatedAt = $updatedAt;
     }


### PR DESCRIPTION
Fixing the BC break described in #496:  v1 had left `updatedAt` as `null`, if an entity was never updated. v2 introduces that `updatedAt` is initialized with the same timestamp as `createdAt`, so `updatedAt` cannot be `null` anymore. This PR changes the signature of `getUpdatedAt()` and `setUpdatedAt()` to allow null values again for legacy data (just to be consistent, as setting `updatedAt` to null will be overwritten on save).