### PR TITLE
Make:entity dispatches event with incomplete argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /vendor
 composer.lock
-
+.idea
 .phpunit.result.cache
 
 config/secrets/*

--- a/src/EventSubscriber/BlameableSubscriber.php
+++ b/src/EventSubscriber/BlameableSubscriber.php
@@ -62,6 +62,10 @@ final class BlameableSubscriber implements EventSubscriber
     public function loadClassMetadata(LoadClassMetadataEventArgs $loadClassMetadataEventArgs): void
     {
         $classMetadata = $loadClassMetadataEventArgs->getClassMetadata();
+        if ($classMetadata->reflClass === null) {
+            // Class has not yet been fully built, ignore this event
+            return;
+        }
 
         if (! is_a($classMetadata->reflClass->getName(), BlameableInterface::class, true)) {
             return;

--- a/src/EventSubscriber/SoftDeletableSubscriber.php
+++ b/src/EventSubscriber/SoftDeletableSubscriber.php
@@ -42,6 +42,10 @@ final class SoftDeletableSubscriber implements EventSubscriber
     public function loadClassMetadata(LoadClassMetadataEventArgs $loadClassMetadataEventArgs): void
     {
         $classMetadata = $loadClassMetadataEventArgs->getClassMetadata();
+        if ($classMetadata->reflClass === null) {
+            // Class has not yet been fully built, ignore this event
+            return;
+        }
 
         if (! is_a($classMetadata->reflClass->getName(), SoftDeletableInterface::class, true)) {
             return;

--- a/src/EventSubscriber/TimestampableSubscriber.php
+++ b/src/EventSubscriber/TimestampableSubscriber.php
@@ -27,6 +27,11 @@ final class TimestampableSubscriber implements EventSubscriber
     public function loadClassMetadata(LoadClassMetadataEventArgs $loadClassMetadataEventArgs): void
     {
         $classMetadata = $loadClassMetadataEventArgs->getClassMetadata();
+        if ($classMetadata->reflClass === null) {
+            // Class has not yet been fully built, ignore this event
+            return;
+        }
+
         if (! is_a($classMetadata->reflClass->getName(), TimestampableInterface::class, true)) {
             return;
         }

--- a/src/EventSubscriber/TranslatableSubscriber.php
+++ b/src/EventSubscriber/TranslatableSubscriber.php
@@ -51,6 +51,10 @@ final class TranslatableSubscriber implements EventSubscriber
     public function loadClassMetadata(LoadClassMetadataEventArgs $loadClassMetadataEventArgs): void
     {
         $classMetadata = $loadClassMetadataEventArgs->getClassMetadata();
+        if ($classMetadata->reflClass === null) {
+            // Class has not yet been fully built, ignore this event
+            return;
+        }
 
         if ($classMetadata->isMappedSuperclass) {
             return;

--- a/src/EventSubscriber/TreeSubscriber.php
+++ b/src/EventSubscriber/TreeSubscriber.php
@@ -14,6 +14,10 @@ final class TreeSubscriber implements EventSubscriber
     public function loadClassMetadata(LoadClassMetadataEventArgs $loadClassMetadataEventArgs): void
     {
         $classMetadata = $loadClassMetadataEventArgs->getClassMetadata();
+        if ($classMetadata->reflClass === null) {
+            // Class has not yet been fully built, ignore this event
+            return;
+        }
 
         if (! is_a($classMetadata->reflClass->getName(), TreeNodeInterface::class, true)) {
             return;

--- a/src/EventSubscriber/UuidableSubscriber.php
+++ b/src/EventSubscriber/UuidableSubscriber.php
@@ -15,6 +15,10 @@ final class UuidableSubscriber implements EventSubscriber
     public function loadClassMetadata(LoadClassMetadataEventArgs $loadClassMetadataEventArgs): void
     {
         $classMetadata = $loadClassMetadataEventArgs->getClassMetadata();
+        if ($classMetadata->reflClass === null) {
+            // Class has not yet been fully built, ignore this event
+            return;
+        }
 
         if (! is_a($classMetadata->reflClass->getName(), UuidableInterface::class, true)) {
             return;

--- a/tests/ORM/TimestampableMakeEntityTest.php
+++ b/tests/ORM/TimestampableMakeEntityTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Knp\DoctrineBehaviors\Tests\ORM;
+
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
+use Doctrine\ORM\Events;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Knp\DoctrineBehaviors\Tests\AbstractBehaviorTestCase;
+
+/**
+ * When console make:entity creates a new class, the event arguments are not fully populated
+ *
+ * This test emulates the event dispatch near the end of method
+ *   Doctrine\ORM\Mapping\ClassMetadataFactory::doLoadMetadata()
+ *
+ * @property EntityManager $entityManager
+ */
+final class TimestampableMakeEntityTest extends AbstractBehaviorTestCase
+{
+    public function testMakeEntityEmptyEvent(): void
+    {
+        $className = 'App\Entity\MyClass';
+        $class = new ClassMetadata($className);
+        $eventArgs = new LoadClassMetadataEventArgs($class, $this->entityManager);
+        $doctrineEventManager = $this->entityManager->getEventManager();
+        $doctrineEventManager->dispatchEvent(Events::loadClassMetadata, $eventArgs);
+        $this->expectNotToPerformAssertions();
+    }
+
+    protected function provideCustomConfig(): ?string
+    {
+        return __DIR__ . '/../config/config_test_with_timestampable_entity.yaml';
+    }
+}

--- a/tests/config/config_test_with_timestampable_entity.yaml
+++ b/tests/config/config_test_with_timestampable_entity.yaml
@@ -1,0 +1,26 @@
+services:
+    _defaults:
+        public: true
+        autowire: true
+
+    Knp\DoctrineBehaviors\EventSubscriber\BlameableSubscriber:
+        tags:
+            - { name: 'doctrine.event_subscriber' }
+    Knp\DoctrineBehaviors\EventSubscriber\LoggableSubscriber:
+        tags:
+            - { name: 'doctrine.event_subscriber' }
+    Knp\DoctrineBehaviors\EventSubscriber\SluggableSubscriber:
+        tags:
+            - { name: 'doctrine.event_subscriber' }
+    Knp\DoctrineBehaviors\EventSubscriber\SoftDeletableSubscriber:
+        tags:
+            - { name: 'doctrine.event_subscriber' }
+    Knp\DoctrineBehaviors\EventSubscriber\TimestampableSubscriber:
+        tags:
+            - { name: 'doctrine.event_subscriber' }
+    Knp\DoctrineBehaviors\EventSubscriber\TreeSubscriber:
+        tags:
+            - { name: 'doctrine.event_subscriber' }
+    Knp\DoctrineBehaviors\EventSubscriber\UuidableSubscriber:
+        tags:
+            - { name: 'doctrine.event_subscriber' }


### PR DESCRIPTION
Resolves issue #481 by checking for a null reflection class pointer before
using the pointer, in each of the event subscribers.