### PR TITLE
PHPStan: generics on Transatable/Translation

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -44,8 +44,5 @@ parameters:
 
         - '#Cannot call method addChildNode\(\) on Knp\\DoctrineBehaviors\\Contract\\Entity\\TreeNodeInterface\|null#'
 
-        # iterable
-        - '#Parameter \#1 \$translations of method Knp\\DoctrineBehaviors\\Tests\\Fixtures\\Entity\\TranslatableEntity\:\:setTranslations\(\) expects Doctrine\\Common\\Collections\\Collection&iterable<Knp\\DoctrineBehaviors\\Contract\\Entity\\TranslationInterface\>, array<int, Knp\\DoctrineBehaviors\\Contract\\Entity\\TranslationInterface\> given#'
-
         - '#Property Knp\\DoctrineBehaviors\\Provider\\LocaleProvider\:\:\$translator has no typehint specified#'
         - '#PHPDoc tag @var has invalid value \(TranslatorInterface&LocaleAwareInterface\|null\)\: Unexpected token "\|", expected TOKEN_OTHER at offset 56#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,9 +11,6 @@ parameters:
     reportUnmatchedIgnoredErrors: false
 
     ignoreErrors:
-        # traits
-        - '#Call to an undefined method Knp\\DoctrineBehaviors(.*?)#'
-
         # buggy
         - '#of function call_user_func_array expects callable#'
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,6 +11,21 @@ parameters:
     reportUnmatchedIgnoredErrors: false
 
     ignoreErrors:
+        # traits
+        - '#Call to an undefined method Knp\\DoctrineBehaviors\\Contract\\Provider\\UserProviderInterface::changeUser\(\)#'
+        - '#Call to an undefined method Knp\\DoctrineBehaviors\\Contract\\Entity\\SluggableInterface::getId\(\)#'
+        - '#Call to an undefined method Knp\\DoctrineBehaviors\\Contract\\Entity\\TreeNodeInterface::getId\(\)#'
+        - '#Call to an undefined method Knp\\DoctrineBehaviors\\Contract\\Entity\\TreeNodeInterface::to(Flat)?Array\(\)#'
+
+        # translation proxy
+        - message: '#Call to an undefined method Knp\\DoctrineBehaviors\\Tests\\Fixtures\\Entity\\TranslatableEntity::(get|set)Title\(\)#'
+          path: tests/ORM/TranslatableTest.php
+
+        # translation inheritance, I don't wanted to change (Abstract|Extended)TranslationEntity(Translation)? classes
+        # to had generics support because it feels super weird and inheritance was legit useless.
+        - message: '#Call to an undefined method Knp\\DoctrineBehaviors\\Contract\\Entity\\TranslationInterface::(get|set)(Extended)?Title\(\)#'
+          path: tests/ORM/TranslatableInheritanceTest.php
+
         # buggy
         - '#of function call_user_func_array expects callable#'
 

--- a/src/Contract/Entity/TranslatableInterface.php
+++ b/src/Contract/Entity/TranslatableInterface.php
@@ -6,20 +6,31 @@ namespace Knp\DoctrineBehaviors\Contract\Entity;
 
 use Doctrine\Common\Collections\Collection;
 
+/**
+ * @phpstan-template T of TranslationInterface
+ */
 interface TranslatableInterface
 {
     /**
      * @return Collection|TranslationInterface[]
+     * @phpstan-return Collection<string,T>|T[]
      */
     public function getTranslations();
 
     /**
      * @return Collection|TranslationInterface[]
+     * @phpstan-return Collection<string,T>|T[]
      */
     public function getNewTranslations();
 
+    /**
+     * @phpstan-param T $translation
+     */
     public function addTranslation(TranslationInterface $translation): void;
 
+    /**
+     * @phpstan-param T $translation
+     */
     public function removeTranslation(TranslationInterface $translation): void;
 
     /**
@@ -29,6 +40,8 @@ interface TranslatableInterface
      * In order to persist new translations, call mergeNewTranslations method, before flush
      *
      * @param string $locale The locale (en, ru, fr) | null If null, will try with current locale
+     *
+     * @phpstan-return T
      */
     public function translate(?string $locale = null, bool $fallbackToDefault = true): TranslationInterface;
 

--- a/src/Contract/Entity/TranslationInterface.php
+++ b/src/Contract/Entity/TranslationInterface.php
@@ -4,12 +4,21 @@ declare(strict_types=1);
 
 namespace Knp\DoctrineBehaviors\Contract\Entity;
 
+/**
+ * @phpstan-template T of TranslatableInterface
+ */
 interface TranslationInterface
 {
     public static function getTranslatableEntityClass(): string;
 
+    /**
+     * @phpstan-param T $translatable
+     */
     public function setTranslatable(TranslatableInterface $translatable): void;
 
+    /**
+     * @phpstan-return T
+     */
     public function getTranslatable(): TranslatableInterface;
 
     public function setLocale(string $locale): void;

--- a/src/Model/Translatable/TranslatableMethodsTrait.php
+++ b/src/Model/Translatable/TranslatableMethodsTrait.php
@@ -144,6 +144,7 @@ trait TranslatableMethodsTrait
             return $translation;
         }
 
+        /** @var TranslationInterface $translation */
         $class = static::getTranslationEntityClass();
 
         $translation = new $class();

--- a/src/Model/Translatable/TranslatableMethodsTrait.php
+++ b/src/Model/Translatable/TranslatableMethodsTrait.php
@@ -11,9 +11,6 @@ use Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface;
 
 trait TranslatableMethodsTrait
 {
-    /**
-     * {@inheritDoc}
-     */
     public function getTranslations()
     {
         // initialize collection, usually in ctor
@@ -24,9 +21,6 @@ trait TranslatableMethodsTrait
         return $this->translations;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function setTranslations(iterable $translations): void
     {
         $this->ensureIsIterableOrCollection($translations);
@@ -36,9 +30,6 @@ trait TranslatableMethodsTrait
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function getNewTranslations()
     {
         // initialize collection, usually in ctor
@@ -49,26 +40,17 @@ trait TranslatableMethodsTrait
         return $this->newTranslations;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function addTranslation(TranslationInterface $translation): void
     {
         $this->getTranslations()->set((string) $translation->getLocale(), $translation);
         $translation->setTranslatable($this);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function removeTranslation(TranslationInterface $translation): void
     {
         $this->getTranslations()->removeElement($translation);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function translate(?string $locale = null, bool $fallbackToDefault = true): TranslationInterface
     {
         return $this->doTranslate($locale, $fallbackToDefault);

--- a/src/Model/Translatable/TranslatableMethodsTrait.php
+++ b/src/Model/Translatable/TranslatableMethodsTrait.php
@@ -12,7 +12,7 @@ use Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface;
 trait TranslatableMethodsTrait
 {
     /**
-     * @return Collection|TranslationInterface[]
+     * {@inheritDoc}
      */
     public function getTranslations()
     {
@@ -25,7 +25,7 @@ trait TranslatableMethodsTrait
     }
 
     /**
-     * @param Collection|TranslationInterface[] $translations
+     * {@inheritDoc}
      */
     public function setTranslations(iterable $translations): void
     {
@@ -37,7 +37,7 @@ trait TranslatableMethodsTrait
     }
 
     /**
-     * @return Collection|TranslationInterface[]
+     * {@inheritDoc}
      */
     public function getNewTranslations()
     {
@@ -49,24 +49,25 @@ trait TranslatableMethodsTrait
         return $this->newTranslations;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function addTranslation(TranslationInterface $translation): void
     {
         $this->getTranslations()->set((string) $translation->getLocale(), $translation);
         $translation->setTranslatable($this);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function removeTranslation(TranslationInterface $translation): void
     {
         $this->getTranslations()->removeElement($translation);
     }
 
     /**
-     * Returns translation for specific locale (creates new one if doesn't exists).
-     * If requested translation doesn't exist, it will first try to fallback default locale
-     * If any translation doesn't exist, it will be added to newTranslations collection.
-     * In order to persist new translations, call mergeNewTranslations method, before flush
-     *
-     * @param string $locale The locale (en, ru, fr) | null If null, will try with current locale
+     * {@inheritDoc}
      */
     public function translate(?string $locale = null, bool $fallbackToDefault = true): TranslationInterface
     {
@@ -130,7 +131,7 @@ trait TranslatableMethodsTrait
      *
      * @param string $locale The locale (en, ru, fr) | null If null, will try with current locale
      */
-    protected function doTranslate(?string $locale = null, bool $fallbackToDefault = true): TranslationInterface
+    protected function doTranslate(?string $locale = null, bool $fallbackToDefault = true)
     {
         if ($locale === null) {
             $locale = $this->getCurrentLocale();
@@ -163,7 +164,6 @@ trait TranslatableMethodsTrait
 
         $class = static::getTranslationEntityClass();
 
-        /** @var TranslationInterface $translation */
         $translation = new $class();
         $translation->setLocale($locale);
 

--- a/src/Model/Translatable/TranslationMethodsTrait.php
+++ b/src/Model/Translatable/TranslationMethodsTrait.php
@@ -17,6 +17,8 @@ trait TranslationMethodsTrait
 
     /**
      * Sets entity, that this translation should be mapped to.
+     *
+     * {@inheritDoc}
      */
     public function setTranslatable(TranslatableInterface $translatable): void
     {
@@ -25,6 +27,8 @@ trait TranslationMethodsTrait
 
     /**
      * Returns entity, that this translation is mapped to.
+     *
+     * {@inheritDoc}
      */
     public function getTranslatable(): TranslatableInterface
     {

--- a/src/Model/Translatable/TranslationPropertiesTrait.php
+++ b/src/Model/Translatable/TranslationPropertiesTrait.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Knp\DoctrineBehaviors\Model\Translatable;
 
-use Knp\DoctrineBehaviors\Contract\Entity\TranslatableInterface;
-
 trait TranslationPropertiesTrait
 {
     /**

--- a/src/Model/Translatable/TranslationPropertiesTrait.php
+++ b/src/Model/Translatable/TranslationPropertiesTrait.php
@@ -15,7 +15,7 @@ trait TranslationPropertiesTrait
 
     /**
      * Will be mapped to translatable entity by TranslatableSubscriber
-     * @var TranslatableInterface
+     * @var mixed
      */
     protected $translatable;
 }

--- a/tests/Fixtures/Entity/SluggableTranslatableEntity.php
+++ b/tests/Fixtures/Entity/SluggableTranslatableEntity.php
@@ -10,6 +10,7 @@ use Knp\DoctrineBehaviors\Model\Translatable\TranslatableTrait;
 
 /**
  * @ORM\Entity
+ * @implements TranslatableInterface<SluggableTranslatableEntityTranslation>
  */
 class SluggableTranslatableEntity implements TranslatableInterface
 {

--- a/tests/Fixtures/Entity/SluggableTranslatableEntity.php
+++ b/tests/Fixtures/Entity/SluggableTranslatableEntity.php
@@ -10,7 +10,7 @@ use Knp\DoctrineBehaviors\Model\Translatable\TranslatableTrait;
 
 /**
  * @ORM\Entity
- * @implements TranslatableInterface<SluggableTranslatableEntityTranslation>
+ * @phpstan-implements TranslatableInterface<SluggableTranslatableEntityTranslation>
  */
 class SluggableTranslatableEntity implements TranslatableInterface
 {

--- a/tests/Fixtures/Entity/SluggableTranslatableEntityTranslation.php
+++ b/tests/Fixtures/Entity/SluggableTranslatableEntityTranslation.php
@@ -12,7 +12,7 @@ use Knp\DoctrineBehaviors\Model\Translatable\TranslationTrait;
 
 /**
  * @ORM\Entity
- * @implements TranslationInterface<SluggableTranslatableEntity>
+ * @phpstan-implements TranslationInterface<SluggableTranslatableEntity>
  */
 class SluggableTranslatableEntityTranslation implements TranslationInterface, SluggableInterface
 {

--- a/tests/Fixtures/Entity/SluggableTranslatableEntityTranslation.php
+++ b/tests/Fixtures/Entity/SluggableTranslatableEntityTranslation.php
@@ -12,6 +12,7 @@ use Knp\DoctrineBehaviors\Model\Translatable\TranslationTrait;
 
 /**
  * @ORM\Entity
+ * @implements TranslationInterface<SluggableTranslatableEntity>
  */
 class SluggableTranslatableEntityTranslation implements TranslationInterface, SluggableInterface
 {

--- a/tests/Fixtures/Entity/TranslatableCustomizedEntity.php
+++ b/tests/Fixtures/Entity/TranslatableCustomizedEntity.php
@@ -10,8 +10,10 @@ use Knp\DoctrineBehaviors\Model\Translatable\TranslatableTrait;
 use Knp\DoctrineBehaviors\Tests\Fixtures\Entity\Translation\TranslatableCustomizedEntityTranslation;
 
 /**
- * @ORM\Entity
  * Used to test translation classes which declare custom translatable classes.
+ *
+ * @ORM\Entity
+ * @implements TranslatableInterface<TranslatableCustomizedEntityTranslation>
  */
 class TranslatableCustomizedEntity implements TranslatableInterface
 {

--- a/tests/Fixtures/Entity/TranslatableCustomizedEntity.php
+++ b/tests/Fixtures/Entity/TranslatableCustomizedEntity.php
@@ -13,7 +13,7 @@ use Knp\DoctrineBehaviors\Tests\Fixtures\Entity\Translation\TranslatableCustomiz
  * Used to test translation classes which declare custom translatable classes.
  *
  * @ORM\Entity
- * @implements TranslatableInterface<TranslatableCustomizedEntityTranslation>
+ * @phpstan-implements TranslatableInterface<TranslatableCustomizedEntityTranslation>
  */
 class TranslatableCustomizedEntity implements TranslatableInterface
 {

--- a/tests/Fixtures/Entity/TranslatableEntity.php
+++ b/tests/Fixtures/Entity/TranslatableEntity.php
@@ -10,7 +10,7 @@ use Knp\DoctrineBehaviors\Model\Translatable\TranslatableTrait;
 
 /**
  * @ORM\Entity
- * @implements TranslatableInterface<TranslatableEntityTranslation>
+ * @phpstan-implements TranslatableInterface<TranslatableEntityTranslation>
  */
 class TranslatableEntity implements TranslatableInterface
 {

--- a/tests/Fixtures/Entity/TranslatableEntity.php
+++ b/tests/Fixtures/Entity/TranslatableEntity.php
@@ -10,6 +10,7 @@ use Knp\DoctrineBehaviors\Model\Translatable\TranslatableTrait;
 
 /**
  * @ORM\Entity
+ * @implements TranslatableInterface<TranslatableEntityTranslation>
  */
 class TranslatableEntity implements TranslatableInterface
 {

--- a/tests/Fixtures/Entity/TranslatableEntityTranslation.php
+++ b/tests/Fixtures/Entity/TranslatableEntityTranslation.php
@@ -10,7 +10,7 @@ use Knp\DoctrineBehaviors\Model\Translatable\TranslationTrait;
 
 /**
  * @ORM\Entity
- * @implements TranslationInterface<TranslatableEntity>
+ * @phpstan-implements TranslationInterface<TranslatableEntity>
  */
 class TranslatableEntityTranslation implements TranslationInterface
 {

--- a/tests/Fixtures/Entity/TranslatableEntityTranslation.php
+++ b/tests/Fixtures/Entity/TranslatableEntityTranslation.php
@@ -10,6 +10,7 @@ use Knp\DoctrineBehaviors\Model\Translatable\TranslationTrait;
 
 /**
  * @ORM\Entity
+ * @implements TranslationInterface<TranslatableEntity>
  */
 class TranslatableEntityTranslation implements TranslationInterface
 {

--- a/tests/Fixtures/Entity/Translation/TranslatableCustomizedEntityTranslation.php
+++ b/tests/Fixtures/Entity/Translation/TranslatableCustomizedEntityTranslation.php
@@ -10,8 +10,9 @@ use Knp\DoctrineBehaviors\Model\Translatable\TranslationTrait;
 use Knp\DoctrineBehaviors\Tests\Fixtures\Entity\TranslatableCustomizedEntity;
 
 /**
- * @ORM\Entity
  * Used to test translatable classes which declare a custom translation class.
+ * @ORM\Entity
+ * @implements TranslationInterface<TranslatableCustomizedEntity>
  */
 class TranslatableCustomizedEntityTranslation implements TranslationInterface
 {

--- a/tests/Fixtures/Entity/Translation/TranslatableCustomizedEntityTranslation.php
+++ b/tests/Fixtures/Entity/Translation/TranslatableCustomizedEntityTranslation.php
@@ -12,7 +12,7 @@ use Knp\DoctrineBehaviors\Tests\Fixtures\Entity\TranslatableCustomizedEntity;
 /**
  * Used to test translatable classes which declare a custom translation class.
  * @ORM\Entity
- * @implements TranslationInterface<TranslatableCustomizedEntity>
+ * @phpstan-implements TranslationInterface<TranslatableCustomizedEntity>
  */
 class TranslatableCustomizedEntityTranslation implements TranslationInterface
 {

--- a/tests/ORM/TranslatableInheritanceTest.php
+++ b/tests/ORM/TranslatableInheritanceTest.php
@@ -43,7 +43,7 @@ final class TranslatableInheritanceTest extends AbstractBehaviorTestCase
 
         $this->entityManager->clear();
 
-        /** @var TranslatableInterface $entity */
+        /** @var ExtendedTranslatableEntity $entity */
         $entity = $this->objectRepository->find($id);
 
         $this->assertSame('fabuleux', $entity->translate('fr')->getTitle());

--- a/tests/ORM/TranslatableInheritanceTest.php
+++ b/tests/ORM/TranslatableInheritanceTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Knp\DoctrineBehaviors\Tests\ORM;
 
 use Doctrine\Persistence\ObjectRepository;
-use Knp\DoctrineBehaviors\Contract\Entity\TranslatableInterface;
 use Knp\DoctrineBehaviors\Tests\AbstractBehaviorTestCase;
 use Knp\DoctrineBehaviors\Tests\Fixtures\Entity\Translatable\ExtendedTranslatableEntity;
 

--- a/tests/ORM/TranslatableTest.php
+++ b/tests/ORM/TranslatableTest.php
@@ -269,7 +269,7 @@ final class TranslatableTest extends AbstractBehaviorTestCase
         $entity = new TranslatableEntity();
         $entity->addTranslation($entityTranslation);
 
-        $this->assertEquals('My title', $entityTranslation->getTranslatable()->translate('en')->getTitle());
+        $this->assertSame('My title', $entityTranslation->getTranslatable()->translate('en')->getTitle());
     }
 
     /**

--- a/tests/ORM/TranslatableTest.php
+++ b/tests/ORM/TranslatableTest.php
@@ -260,6 +260,18 @@ final class TranslatableTest extends AbstractBehaviorTestCase
         $this->assertSame('удивительный', $entity->translate('ru')->getTitle());
     }
 
+    public function testTranslationTranslatable(): void
+    {
+        $entityTranslation = new TranslatableEntityTranslation();
+        $entityTranslation->setLocale('en');
+        $entityTranslation->setTitle('My title');
+
+        $entity = new TranslatableEntity();
+        $entity->addTranslation($entityTranslation);
+
+        $this->assertEquals('My title', $entityTranslation->getTranslatable()->translate('en')->getTitle());
+    }
+
     /**
      * Asserts that the one to many relationship between translatable and translations is mapped correctly.
      */


### PR DESCRIPTION
This PR is a proposal for #516. 

The following code:
![Capture d’écran de 2020-02-04 07-09-01](https://user-images.githubusercontent.com/2103975/73718621-5c840100-471d-11ea-8b8a-b7bff5f93203.png)

Will now be analysed correctly by PHPStan:
![Capture d’écran de 2020-02-04 07-09-19](https://user-images.githubusercontent.com/2103975/73718620-5c840100-471d-11ea-817b-7346dbd2469d.png)