### PR TITLE
Add PHPStan extensions, for Translatable/Translation interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,21 @@ final class CategoryRepository extends EntityRepository
 
 Voilá!
 
-You now have a working `Category` that behaves like:
+You now have a working `Category` that behaves like.
+
+## PHPStan
+
+A PHPStan is available and provides the following features:
+  - Provides correct return type for `TranslatableInterface::getTranslations()` and `TranslatableInterface::getNewTranslations()`
+  - Provides correct return type for `TranslatableInterface::translate()`
+  - Provides correct return type for `TranslationInterface::getTranslatable()`
+
+Include `extension.neon` in your project's PHPStan config:
+```yaml
+# phpstan.neon
+includes:
+    - vendor/knplabs/doctrine-behaviors/extension.neon
+```
 
 ## 3 Steps to Contribute
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ You now have a working `Category` that behaves like.
 
 ## PHPStan
 
-A PHPStan is available and provides the following features:
+A PHPStan extension is available and provides the following features:
   - Provides correct return type for `TranslatableInterface::getTranslations()` and `TranslatableInterface::getNewTranslations()`
   - Provides correct return type for `TranslatableInterface::translate()`
   - Provides correct return type for `TranslationInterface::getTranslatable()`

--- a/extension.neon
+++ b/extension.neon
@@ -1,0 +1,10 @@
+services:
+    -
+        class: Knp\DoctrineBehaviors\PHPStan\Type\TranslatableTranslateDynamicMethodReturnTypeExtension
+        tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
+    -
+        class: Knp\DoctrineBehaviors\PHPStan\Type\TranslatableGetTranslationsDynamicMethodReturnTypeExtension
+        tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
+    -
+        class: Knp\DoctrineBehaviors\PHPStan\Type\TranslationGetTranslatableDynamicMethodReturnTypeExtension
+        tags: [phpstan.broker.dynamicMethodReturnTypeExtension]

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,5 @@
 includes:
+    - extension.neon
     - vendor/symplify/phpstan-extensions/config/config.neon
     - vendor/phpstan/phpstan-doctrine/extension.neon
     - vendor/phpstan/phpstan-phpunit/extension.neon

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -16,7 +16,10 @@ parameters:
 
     ignoreErrors:
         # traits
-        - '#Call to an undefined method Knp\\DoctrineBehaviors(.*?)#'
+        - '#Call to an undefined method Knp\\DoctrineBehaviors\\Contract\\Provider\\UserProviderInterface::changeUser\(\)#'
+        - '#Call to an undefined method Knp\\DoctrineBehaviors\\Contract\\Entity\\SluggableInterface::getId\(\)#'
+        - '#Call to an undefined method Knp\\DoctrineBehaviors\\Contract\\Entity\\TreeNodeInterface::getId\(\)#'
+        - '#Call to an undefined method Knp\\DoctrineBehaviors\\Contract\\Entity\\TreeNodeInterface::to(Flat)?Array\(\)#'
 
         # buggy
         - '#of function call_user_func_array expects callable#'
@@ -35,9 +38,6 @@ parameters:
         - '#Offset 0 does not exist on array<Knp\\DoctrineBehaviors\\Contract\\Entity\\TreeNodeInterface\>\|ArrayAccess\|null#'
 
         - '#Cannot call method addChildNode\(\) on Knp\\DoctrineBehaviors\\Contract\\Entity\\TreeNodeInterface\|null#'
-
-        # iterable
-        - '#Parameter \#1 \$translations of method Knp\\DoctrineBehaviors\\Tests\\Fixtures\\Entity\\TranslatableEntity\:\:setTranslations\(\) expects Doctrine\\Common\\Collections\\Collection&iterable<Knp\\DoctrineBehaviors\\Contract\\Entity\\TranslationInterface\>, array<int, Knp\\DoctrineBehaviors\\Contract\\Entity\\TranslationInterface\> given#'
 
         - '#Property Knp\\DoctrineBehaviors\\Provider\\LocaleProvider\:\:\$translator has no typehint specified#'
         - '#PHPDoc tag @var has invalid value \(TranslatorInterface&LocaleAwareInterface\|null\)\: Unexpected token "\|", expected TOKEN_OTHER at offset 56#'

--- a/src/Model/Translatable/TranslatableMethodsTrait.php
+++ b/src/Model/Translatable/TranslatableMethodsTrait.php
@@ -26,6 +26,7 @@ trait TranslatableMethodsTrait
 
     /**
      * @param Collection|TranslationInterface[] $translations
+     * @phpstan-param iterable<TranslationInterface> $translations
      */
     public function setTranslations(iterable $translations): void
     {

--- a/src/PHPStan/Type/Helper.php
+++ b/src/PHPStan/Type/Helper.php
@@ -1,17 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Knp\DoctrineBehaviors\PHPStan\Type;
 
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Broker\Broker;
-use PHPStan\Reflection\MethodReflection;
 
 final class Helper
 {
     public static function getTranslationClass(Broker $broker, MethodCall $methodCall, Scope $scope): string
     {
-        $type              = $scope->getType($methodCall->var);
+        $type = $scope->getType($methodCall->var);
         $translatableClass = $type->getReferencedClasses()[0];
 
         return $broker
@@ -23,7 +24,7 @@ final class Helper
 
     public static function getTranslatableClass(Broker $broker, MethodCall $methodCall, Scope $scope): string
     {
-        $type              = $scope->getType($methodCall->var);
+        $type = $scope->getType($methodCall->var);
         $translatableClass = $type->getReferencedClasses()[0];
 
         return $broker

--- a/src/PHPStan/Type/Helper.php
+++ b/src/PHPStan/Type/Helper.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Knp\DoctrineBehaviors\PHPStan\Type;
+
+use PHPStan\Reflection\MethodReflection;
+
+final class Helper
+{
+    public static function getTranslationClassFromMethodReflection(MethodReflection $methodReflection): string
+    {
+        $translatableReflection       = $methodReflection->getDeclaringClass();
+        $translatableNativeReflection = $translatableReflection->getNativeReflection();
+
+        return $translatableNativeReflection->getMethod('getTranslationEntityClass')->invoke(null);
+    }
+
+    public static function getTranslatableClassFromMethodReflection(MethodReflection $methodReflection): string
+    {
+        $translationReflection       = $methodReflection->getDeclaringClass();
+        $translationNativeReflection = $translationReflection->getNativeReflection();
+
+        return $translationNativeReflection->getMethod('getTranslatableEntityClass')->invoke(null);
+    }
+}

--- a/src/PHPStan/Type/Helper.php
+++ b/src/PHPStan/Type/Helper.php
@@ -2,23 +2,34 @@
 
 namespace Knp\DoctrineBehaviors\PHPStan\Type;
 
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Broker\Broker;
 use PHPStan\Reflection\MethodReflection;
 
 final class Helper
 {
-    public static function getTranslationClassFromMethodReflection(MethodReflection $methodReflection): string
+    public static function getTranslationClass(Broker $broker, MethodCall $methodCall, Scope $scope): string
     {
-        $translatableReflection       = $methodReflection->getDeclaringClass();
-        $translatableNativeReflection = $translatableReflection->getNativeReflection();
+        $type              = $scope->getType($methodCall->var);
+        $translatableClass = $type->getReferencedClasses()[0];
 
-        return $translatableNativeReflection->getMethod('getTranslationEntityClass')->invoke(null);
+        return $broker
+            ->getClass($translatableClass)
+            ->getNativeReflection()
+            ->getMethod('getTranslationEntityClass')
+            ->invoke(null);
     }
 
-    public static function getTranslatableClassFromMethodReflection(MethodReflection $methodReflection): string
+    public static function getTranslatableClass(Broker $broker, MethodCall $methodCall, Scope $scope): string
     {
-        $translationReflection       = $methodReflection->getDeclaringClass();
-        $translationNativeReflection = $translationReflection->getNativeReflection();
+        $type              = $scope->getType($methodCall->var);
+        $translatableClass = $type->getReferencedClasses()[0];
 
-        return $translationNativeReflection->getMethod('getTranslatableEntityClass')->invoke(null);
+        return $broker
+            ->getClass($translatableClass)
+            ->getNativeReflection()
+            ->getMethod('getTranslatableEntityClass')
+            ->invoke(null);
     }
 }

--- a/src/PHPStan/Type/TranslatableGetTranslationsDynamicMethodReturnTypeExtension.php
+++ b/src/PHPStan/Type/TranslatableGetTranslationsDynamicMethodReturnTypeExtension.php
@@ -8,6 +8,8 @@ use Doctrine\Common\Collections\Collection;
 use Knp\DoctrineBehaviors\Contract\Entity\TranslatableInterface;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\Broker\Broker;
+use PHPStan\Reflection\BrokerAwareExtension;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\IterableType;
@@ -15,8 +17,16 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\TypeCombinator;
 
-final class TranslatableGetTranslationsDynamicMethodReturnTypeExtension implements DynamicMethodReturnTypeExtension
+final class TranslatableGetTranslationsDynamicMethodReturnTypeExtension implements DynamicMethodReturnTypeExtension, BrokerAwareExtension
 {
+    /** @var Broker */
+    private $broker;
+
+    public function setBroker(Broker $broker): void
+    {
+        $this->broker = $broker;
+    }
+
     public function getClass(): string
     {
         return TranslatableInterface::class;
@@ -29,7 +39,7 @@ final class TranslatableGetTranslationsDynamicMethodReturnTypeExtension implemen
 
     public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): \PHPStan\Type\Type
     {
-        $translationClass = Helper::getTranslationClassFromMethodReflection($methodReflection);
+        $translationClass = Helper::getTranslationClass($this->broker, $methodCall, $scope);
 
         return TypeCombinator::intersect(
             new ObjectType(Collection::class),

--- a/src/PHPStan/Type/TranslatableGetTranslationsDynamicMethodReturnTypeExtension.php
+++ b/src/PHPStan/Type/TranslatableGetTranslationsDynamicMethodReturnTypeExtension.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Knp\DoctrineBehaviors\PHPStan\Type;
+
+use Doctrine\Common\Collections\Collection;
+use Knp\DoctrineBehaviors\Contract\Entity\TranslatableInterface;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\IterableType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\TypeCombinator;
+
+final class TranslatableGetTranslationsDynamicMethodReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+    public function getClass(): string
+    {
+        return TranslatableInterface::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return \in_array($methodReflection->getName(), ['getTranslations', 'getNewTranslations'], true);
+    }
+
+    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): \PHPStan\Type\Type
+    {
+        $translationClass = Helper::getTranslationClassFromMethodReflection($methodReflection);
+
+        return TypeCombinator::intersect(
+            new ObjectType(Collection::class),
+            new IterableType(new MixedType(), new ObjectType($translationClass))
+        );
+    }
+}

--- a/src/PHPStan/Type/TranslatableGetTranslationsDynamicMethodReturnTypeExtension.php
+++ b/src/PHPStan/Type/TranslatableGetTranslationsDynamicMethodReturnTypeExtension.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Knp\DoctrineBehaviors\PHPStan\Type;
 
 use Doctrine\Common\Collections\Collection;
+use function in_array;
 use Knp\DoctrineBehaviors\Contract\Entity\TranslatableInterface;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
@@ -15,11 +16,14 @@ use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\IterableType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 
 final class TranslatableGetTranslationsDynamicMethodReturnTypeExtension implements DynamicMethodReturnTypeExtension, BrokerAwareExtension
 {
-    /** @var Broker */
+    /**
+     * @var Broker
+     */
     private $broker;
 
     public function setBroker(Broker $broker): void
@@ -34,11 +38,14 @@ final class TranslatableGetTranslationsDynamicMethodReturnTypeExtension implemen
 
     public function isMethodSupported(MethodReflection $methodReflection): bool
     {
-        return \in_array($methodReflection->getName(), ['getTranslations', 'getNewTranslations'], true);
+        return in_array($methodReflection->getName(), ['getTranslations', 'getNewTranslations'], true);
     }
 
-    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): \PHPStan\Type\Type
-    {
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope
+    ): Type {
         $translationClass = Helper::getTranslationClass($this->broker, $methodCall, $scope);
 
         return TypeCombinator::intersect(

--- a/src/PHPStan/Type/TranslatableTranslateDynamicMethodReturnTypeExtension.php
+++ b/src/PHPStan/Type/TranslatableTranslateDynamicMethodReturnTypeExtension.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Knp\DoctrineBehaviors\PHPStan\Type;
+
+use Knp\DoctrineBehaviors\Contract\Entity\TranslatableInterface;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\ObjectType;
+
+final class TranslatableTranslateDynamicMethodReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+    public function getClass(): string
+    {
+        return TranslatableInterface::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return 'translate' === $methodReflection->getName();
+    }
+
+    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): \PHPStan\Type\Type
+    {
+        $translationClass = Helper::getTranslationClassFromMethodReflection($methodReflection);
+
+        return new ObjectType($translationClass);
+    }
+}

--- a/src/PHPStan/Type/TranslatableTranslateDynamicMethodReturnTypeExtension.php
+++ b/src/PHPStan/Type/TranslatableTranslateDynamicMethodReturnTypeExtension.php
@@ -12,10 +12,13 @@ use PHPStan\Reflection\BrokerAwareExtension;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
 
 final class TranslatableTranslateDynamicMethodReturnTypeExtension implements DynamicMethodReturnTypeExtension, BrokerAwareExtension
 {
-    /** @var Broker */
+    /**
+     * @var Broker
+     */
     private $broker;
 
     public function setBroker(Broker $broker): void
@@ -30,11 +33,14 @@ final class TranslatableTranslateDynamicMethodReturnTypeExtension implements Dyn
 
     public function isMethodSupported(MethodReflection $methodReflection): bool
     {
-        return 'translate' === $methodReflection->getName();
+        return $methodReflection->getName() === 'translate';
     }
 
-    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): \PHPStan\Type\Type
-    {
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope
+    ): Type {
         $translationClass = Helper::getTranslationClass($this->broker, $methodCall, $scope);
 
         return new ObjectType($translationClass);

--- a/src/PHPStan/Type/TranslatableTranslateDynamicMethodReturnTypeExtension.php
+++ b/src/PHPStan/Type/TranslatableTranslateDynamicMethodReturnTypeExtension.php
@@ -7,12 +7,22 @@ namespace Knp\DoctrineBehaviors\PHPStan\Type;
 use Knp\DoctrineBehaviors\Contract\Entity\TranslatableInterface;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\Broker\Broker;
+use PHPStan\Reflection\BrokerAwareExtension;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\ObjectType;
 
-final class TranslatableTranslateDynamicMethodReturnTypeExtension implements DynamicMethodReturnTypeExtension
+final class TranslatableTranslateDynamicMethodReturnTypeExtension implements DynamicMethodReturnTypeExtension, BrokerAwareExtension
 {
+    /** @var Broker */
+    private $broker;
+
+    public function setBroker(Broker $broker): void
+    {
+        $this->broker = $broker;
+    }
+
     public function getClass(): string
     {
         return TranslatableInterface::class;
@@ -25,7 +35,7 @@ final class TranslatableTranslateDynamicMethodReturnTypeExtension implements Dyn
 
     public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): \PHPStan\Type\Type
     {
-        $translationClass = Helper::getTranslationClassFromMethodReflection($methodReflection);
+        $translationClass = Helper::getTranslationClass($this->broker, $methodCall, $scope);
 
         return new ObjectType($translationClass);
     }

--- a/src/PHPStan/Type/TranslationGetTranslatableDynamicMethodReturnTypeExtension.php
+++ b/src/PHPStan/Type/TranslationGetTranslatableDynamicMethodReturnTypeExtension.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Knp\DoctrineBehaviors\PHPStan\Type;
+
+use Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\ObjectType;
+
+final class TranslationGetTranslatableDynamicMethodReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+    public function getClass(): string
+    {
+        return TranslationInterface::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return 'getTranslatable' === $methodReflection->getName();
+    }
+
+    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): \PHPStan\Type\Type
+    {
+        $translatableClass = Helper::getTranslatableClassFromMethodReflection($methodReflection);
+
+        return new ObjectType($translatableClass);
+    }
+}

--- a/src/PHPStan/Type/TranslationGetTranslatableDynamicMethodReturnTypeExtension.php
+++ b/src/PHPStan/Type/TranslationGetTranslatableDynamicMethodReturnTypeExtension.php
@@ -12,10 +12,13 @@ use PHPStan\Reflection\BrokerAwareExtension;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
 
 final class TranslationGetTranslatableDynamicMethodReturnTypeExtension implements DynamicMethodReturnTypeExtension, BrokerAwareExtension
 {
-    /** @var Broker */
+    /**
+     * @var Broker
+     */
     private $broker;
 
     public function setBroker(Broker $broker): void
@@ -30,11 +33,14 @@ final class TranslationGetTranslatableDynamicMethodReturnTypeExtension implement
 
     public function isMethodSupported(MethodReflection $methodReflection): bool
     {
-        return 'getTranslatable' === $methodReflection->getName();
+        return $methodReflection->getName() === 'getTranslatable';
     }
 
-    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): \PHPStan\Type\Type
-    {
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope
+    ): Type {
         $translatableClass = Helper::getTranslatableClass($this->broker, $methodCall, $scope);
 
         return new ObjectType($translatableClass);

--- a/src/PHPStan/Type/TranslationGetTranslatableDynamicMethodReturnTypeExtension.php
+++ b/src/PHPStan/Type/TranslationGetTranslatableDynamicMethodReturnTypeExtension.php
@@ -7,12 +7,22 @@ namespace Knp\DoctrineBehaviors\PHPStan\Type;
 use Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\Broker\Broker;
+use PHPStan\Reflection\BrokerAwareExtension;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\ObjectType;
 
-final class TranslationGetTranslatableDynamicMethodReturnTypeExtension implements DynamicMethodReturnTypeExtension
+final class TranslationGetTranslatableDynamicMethodReturnTypeExtension implements DynamicMethodReturnTypeExtension, BrokerAwareExtension
 {
+    /** @var Broker */
+    private $broker;
+
+    public function setBroker(Broker $broker): void
+    {
+        $this->broker = $broker;
+    }
+
     public function getClass(): string
     {
         return TranslationInterface::class;
@@ -25,7 +35,7 @@ final class TranslationGetTranslatableDynamicMethodReturnTypeExtension implement
 
     public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): \PHPStan\Type\Type
     {
-        $translatableClass = Helper::getTranslatableClassFromMethodReflection($methodReflection);
+        $translatableClass = Helper::getTranslatableClass($this->broker, $methodCall, $scope);
 
         return new ObjectType($translatableClass);
     }

--- a/tests/Fixtures/Entity/TranslatableEntity.php
+++ b/tests/Fixtures/Entity/TranslatableEntity.php
@@ -10,6 +10,8 @@ use Knp\DoctrineBehaviors\Model\Translatable\TranslatableTrait;
 
 /**
  * @ORM\Entity
+ * @method string|null getTitle()
+ * @method void setTitle(string $title)
  */
 class TranslatableEntity implements TranslatableInterface
 {

--- a/tests/ORM/TranslatableInheritanceTest.php
+++ b/tests/ORM/TranslatableInheritanceTest.php
@@ -43,7 +43,7 @@ final class TranslatableInheritanceTest extends AbstractBehaviorTestCase
 
         $this->entityManager->clear();
 
-        /** @var TranslatableInterface $entity */
+        /** @var ExtendedTranslatableEntity $entity */
         $entity = $this->objectRepository->find($id);
 
         $this->assertSame('fabuleux', $entity->translate('fr')->getTitle());

--- a/tests/ORM/TranslatableInheritanceTest.php
+++ b/tests/ORM/TranslatableInheritanceTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Knp\DoctrineBehaviors\Tests\ORM;
 
 use Doctrine\Persistence\ObjectRepository;
-use Knp\DoctrineBehaviors\Contract\Entity\TranslatableInterface;
 use Knp\DoctrineBehaviors\Tests\AbstractBehaviorTestCase;
 use Knp\DoctrineBehaviors\Tests\Fixtures\Entity\Translatable\ExtendedTranslatableEntity;
 


### PR DESCRIPTION
This PR is a proposal for #516, and aim to replace #435. 

**Before:** at b8a4b015645af6f53beeabe1f34cb3ba17405206 with 69 errors:

```
➜  DoctrineBehaviors git:(d) vendor/bin/phpstan analyze
Note: Using configuration file /home/kocal/Dev/DoctrineBehaviors/phpstan.neon.
 95/95 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ ----------------------------------------------------------------------------------------------------- 
  Line   tests/ORM/SluggableWithTranslatableEntityAndUniquenessTest.php                                       
 ------ ----------------------------------------------------------------------------------------------------- 
  29     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::setTitle().  
  30     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::setTitle().  
  47     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::getTitle().  
  48     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::getSlug().   
  49     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::getTitle().  
  50     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::getSlug().   
  56     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::setTitle().  
  57     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::setTitle().  
  66     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::getSlug().   
  67     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::getSlug().   
  68     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::setTitle().  
  69     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::setTitle().  
  71     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::getSlug().   
  72     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::getSlug().   
 ------ ----------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------------- 
  Line   tests/ORM/TranslatableInheritanceTest.php                                                                    
 ------ ------------------------------------------------------------------------------------------------------------- 
  29     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::setTitle().          
  30     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::setExtendedTitle().  
  32     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::setTitle().          
  33     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::setExtendedTitle().  
  35     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::setTitle().          
  36     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::setExtendedTitle().  
  49     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::getTitle().          
  50     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::getExtendedTitle().  
  52     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::getTitle().          
  53     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::getExtendedTitle().  
  55     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::getTitle().          
  56     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::getExtendedTitle().  
 ------ ------------------------------------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------------------------------------------------- 
  Line   tests/ORM/TranslatableTest.php                                                                                                  
 ------ -------------------------------------------------------------------------------------------------------------------------------- 
  33     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::setTitle().                             
  34     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::setTitle().                             
  35     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::setTitle().                             
  47     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::getTitle().                             
  48     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::getTitle().                             
  49     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::getTitle().                             
  55     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::setTitle().                             
  56     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::setTitle().                             
  57     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::setTitle().                             
  69     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::getTitle().                             
  70     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::getTitle().                             
  71     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::getTitle().                             
  77     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::setTitle().                             
  78     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::setTitle().                             
  90     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::getTitle().                             
  91     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::getTitle().                             
  93     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::setTitle().                             
  94     Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::setTitle().                             
  104    Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::getTitle().                             
  105    Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::getTitle().                             
  106    Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::getTitle().                             
  121    Call to an undefined method Knp\DoctrineBehaviors\Tests\Fixtures\Entity\TranslatableEntity::setTitle().                         
  134    Call to an undefined method Knp\DoctrineBehaviors\Tests\Fixtures\Entity\TranslatableEntity::getTitle().                         
  135    Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::getTitle().                             
  141    Call to an undefined method Knp\DoctrineBehaviors\Tests\Fixtures\Entity\TranslatableEntity::setTitle().                         
  154    Call to an undefined method Knp\DoctrineBehaviors\Tests\Fixtures\Entity\TranslatableEntity::getTitle().                         
  156    Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::getTitle().                             
  157    Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::getTitle().                             
  177    Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::setTitle().                             
  178    Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::setTitle().                             
  179    Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::setTitle().                             
  181    Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::getTitle().                             
  188    Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::setTitle().                             
  189    Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::setTitle().                             
  199    Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::getTitle().                             
  207    Parameter #1 $translations of method Knp\DoctrineBehaviors\Tests\Fixtures\Entity\TranslatableEntity::setTranslations() expects  
         Doctrine\Common\Collections\Collection&iterable<Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface>, array<int,         
         Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface> given.                                                              
  215    Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::setTitle().                             
  216    Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::setTitle().                             
  217    Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::setTitle().                             
  239    Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::setTitle().                             
  240    Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::setTitle().                             
  241    Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::setTitle().                             
  247    Call to an undefined method Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface::setTitle().                             
 ------ -------------------------------------------------------------------------------------------------------------------------------- 

                                                                                                                        
 [ERROR] Found 69 errors                                                                                                
                                                                                                                        

💡 Tip of the Day:
One or more properties in your code do not have a phpDoc with a type
but it could be inferred from the constructor to find more bugs.
Use inferPrivatePropertyTypeFromConstructor: true in your phpstan.neon to try it out!

```


**Now:** at last commit, with 0 errors
```
➜  DoctrineBehaviors git:(phpstan-extension) ✗ vendor/bin/phpstan analyze
Note: Using configuration file /home/kocal/Dev/DoctrineBehaviors/phpstan.neon.
 99/99 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%


                                                                                                                        
 [OK] No errors                                                                                                         
                                                                                                                        

💡 Tip of the Day:
One or more properties in your code do not have a phpDoc with a type
but it could be inferred from the constructor to find more bugs.
Use inferPrivatePropertyTypeFromConstructor: true in your phpstan.neon to try it out!
```