### PR TITLE
add type "symfony-bundle" for packagist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "knplabs/doctrine-behaviors",
     "description": "Doctrine Behavior Traits",
+    "type": "symfony-bundle",
     "keywords": [
         "behaviors", "doctrine", "timestampable", "translatable", "blameable", "softdeletable", "tree", "uuid"
     ],


### PR DESCRIPTION
This will allow auto-registering bundles with Symfony Flex. See https://github.com/KnpLabs/DoctrineBehaviors/issues/497#issuecomment-586757750 for details