### PR TITLE
[Timestampable] Move updateTimestamps method to UpdateTimestampsTrait

### DIFF
--- a/src/Model/Timestampable/TimestampableMethodsTrait.php
+++ b/src/Model/Timestampable/TimestampableMethodsTrait.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace Knp\DoctrineBehaviors\Model\Timestampable;
 
-use DateTime;
 use DateTimeInterface;
-use DateTimeZone;
-use Knp\DoctrineBehaviors\Exception\ShouldNotHappenException;
 
 trait TimestampableMethodsTrait
 {
+    use UpdateTimestampsTrait;
+
     public function getCreatedAt(): DateTimeInterface
     {
         return $this->createdAt;
@@ -29,26 +28,5 @@ trait TimestampableMethodsTrait
     public function setUpdatedAt(DateTimeInterface $updatedAt): void
     {
         $this->updatedAt = $updatedAt;
-    }
-
-    /**
-     * Updates createdAt and updatedAt timestamps.
-     */
-    public function updateTimestamps(): void
-    {
-        // Create a datetime with microseconds
-        $dateTime = DateTime::createFromFormat('U.u', sprintf('%.6F', microtime(true)));
-
-        if ($dateTime === false) {
-            throw new ShouldNotHappenException();
-        }
-
-        $dateTime->setTimezone(new DateTimeZone(date_default_timezone_get()));
-
-        if ($this->createdAt === null) {
-            $this->createdAt = $dateTime;
-        }
-
-        $this->updatedAt = $dateTime;
     }
 }

--- a/src/Model/Timestampable/UpdateTimestampsTrait.php
+++ b/src/Model/Timestampable/UpdateTimestampsTrait.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Knp\DoctrineBehaviors\Model\Timestampable;
+
+use DateTime;
+use DateTimeZone;
+use Knp\DoctrineBehaviors\Exception\ShouldNotHappenException;
+
+trait UpdateTimestampsTrait
+{
+    /**
+     * Updates createdAt and updatedAt timestamps.
+     */
+    public function updateTimestamps(): void
+    {
+        // Create a datetime with microseconds
+        $dateTime = DateTime::createFromFormat('U.u', sprintf('%.6F', microtime(true)));
+
+        if ($dateTime === false) {
+            throw new ShouldNotHappenException();
+        }
+
+        $dateTime->setTimezone(new DateTimeZone(date_default_timezone_get()));
+
+        if ($this->createdAt === null) {
+            $this->createdAt = $dateTime;
+        }
+
+        $this->updatedAt = $dateTime;
+    }
+}


### PR DESCRIPTION
Working with e.g. API Platform it may be useful to implement the createdAt and updatedAt methods of the TimestampableInterface yourself to add serialization group with annotations and not having to use YAML files instead for the configuration. Therefore it may be useful if KnpLabs DoctrineBehaviors would offer a trait for just the updateTimestamps method so we dont have to reimplement it ourselves in every project but can use the method of this package that already exists.

Maybe `UpdateTimestampsMethodTrait` will be better than `UpdateTimestampsTrait` as the trait name?