### PR TITLE
[Sluggable] Enable gedmo-like "unique_base" feature

### DIFF
--- a/src/Contract/Repository/SluggableRepositoryInterface.php
+++ b/src/Contract/Repository/SluggableRepositoryInterface.php
@@ -10,5 +10,9 @@ interface SluggableRepositoryInterface
 {
     public function isSlugUniqueFor(SluggableInterface $sluggable, string $uniqueSlug): bool;
 
-    public function isSlugUnique(string $uniqueSlug, SluggableInterface $newOrUpdated, SluggableInterface $exisiting): bool;
+    public function isSlugUnique(
+        string $uniqueSlug,
+        SluggableInterface $newOrUpdated,
+        SluggableInterface $exisiting
+    ): bool;
 }

--- a/src/Contract/Repository/SluggableRepositoryInterface.php
+++ b/src/Contract/Repository/SluggableRepositoryInterface.php
@@ -9,4 +9,6 @@ use Knp\DoctrineBehaviors\Contract\Entity\SluggableInterface;
 interface SluggableRepositoryInterface
 {
     public function isSlugUniqueFor(SluggableInterface $sluggable, string $uniqueSlug): bool;
+
+    public function isSlugUnique(string $uniqueSlug, SluggableInterface $newOrUpdated, SluggableInterface $exisiting): bool;
 }

--- a/src/Contract/Repository/SluggableRepositoryInterface.php
+++ b/src/Contract/Repository/SluggableRepositoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Knp\DoctrineBehaviors\Contract\Repository;
+
+use Knp\DoctrineBehaviors\Contract\Entity\SluggableInterface;
+
+interface SluggableRepositoryInterface
+{
+    public function isSlugUniqueFor(SluggableInterface $sluggable, string $uniqueSlug): bool;
+}

--- a/src/EventSubscriber/SluggableSubscriber.php
+++ b/src/EventSubscriber/SluggableSubscriber.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Knp\DoctrineBehaviors\Contract\Entity\SluggableInterface;
-use Knp\DoctrineBehaviors\Repository\DefaultSluggableRepository;
+use Knp\DoctrineBehaviors\Contract\Repository\SluggableRepositoryInterface;
 
 final class SluggableSubscriber implements EventSubscriber
 {
@@ -21,7 +21,7 @@ final class SluggableSubscriber implements EventSubscriber
     private const SLUG = 'slug';
 
     /**
-     * @var DefaultSluggableRepository
+     * @var SluggableRepositoryInterface
      */
     private $defaultSluggableRepository;
 
@@ -32,7 +32,7 @@ final class SluggableSubscriber implements EventSubscriber
 
     public function __construct(
         EntityManagerInterface $entityManager,
-        DefaultSluggableRepository $defaultSluggableRepository
+        SluggableRepositoryInterface $defaultSluggableRepository
     ) {
         $this->defaultSluggableRepository = $defaultSluggableRepository;
         $this->entityManager = $entityManager;

--- a/src/EventSubscriber/SluggableSubscriber.php
+++ b/src/EventSubscriber/SluggableSubscriber.php
@@ -100,7 +100,7 @@ final class SluggableSubscriber implements EventSubscriber
         $uniqueSlug = $slug;
 
         $sluggableRepository = $this->entityManager->getRepository(get_class($sluggable));
-        if (!$sluggableRepository instanceof SluggableRepositoryInterface) {
+        if (! $sluggableRepository instanceof SluggableRepositoryInterface) {
             $sluggableRepository = $this->defaultSluggableRepository;
         }
 
@@ -114,11 +114,14 @@ final class SluggableSubscriber implements EventSubscriber
         $sluggable->setSlug($uniqueSlug);
     }
 
-    private function isSlugUniqueInUnitOfWork(SluggableRepositoryInterface $repository, SluggableInterface $sluggable, string $uniqueSlug): bool
-    {
+    private function isSlugUniqueInUnitOfWork(
+        SluggableRepositoryInterface $sluggableRepository,
+        SluggableInterface $sluggable,
+        string $uniqueSlug
+    ): bool {
         $scheduledEntities = $this->getOtherScheduledEntities($sluggable);
         foreach ($scheduledEntities as $entity) {
-            if (!$repository->isSlugUnique($uniqueSlug, $sluggable, $entity)) {
+            if (! $sluggableRepository->isSlugUnique($uniqueSlug, $sluggable, $entity)) {
                 return false;
             }
         }

--- a/src/Repository/DefaultSluggableRepository.php
+++ b/src/Repository/DefaultSluggableRepository.php
@@ -6,8 +6,9 @@ namespace Knp\DoctrineBehaviors\Repository;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Knp\DoctrineBehaviors\Contract\Entity\SluggableInterface;
+use Knp\DoctrineBehaviors\Contract\Repository\SluggableRepositoryInterface;
 
-final class DefaultSluggableRepository
+final class DefaultSluggableRepository implements SluggableRepositoryInterface
 {
     /**
      * @var EntityManagerInterface

--- a/src/Repository/DefaultSluggableRepository.php
+++ b/src/Repository/DefaultSluggableRepository.php
@@ -41,4 +41,9 @@ final class DefaultSluggableRepository implements SluggableRepositoryInterface
         return ! (bool) $queryBuilder->getQuery()
             ->getSingleScalarResult();
     }
+
+    public function isSlugUnique(string $uniqueSlug, SluggableInterface $newOrUpdated, SluggableInterface $exisiting): bool
+    {
+        return $uniqueSlug === $exisiting->getSlug();
+    }
 }

--- a/src/Repository/DefaultSluggableRepository.php
+++ b/src/Repository/DefaultSluggableRepository.php
@@ -42,8 +42,11 @@ final class DefaultSluggableRepository implements SluggableRepositoryInterface
             ->getSingleScalarResult();
     }
 
-    public function isSlugUnique(string $uniqueSlug, SluggableInterface $newOrUpdated, SluggableInterface $exisiting): bool
-    {
+    public function isSlugUnique(
+        string $uniqueSlug,
+        SluggableInterface $newOrUpdated,
+        SluggableInterface $exisiting
+    ): bool {
         return $uniqueSlug === $exisiting->getSlug();
     }
 }

--- a/src/Repository/DefaultSluggableRepository.php
+++ b/src/Repository/DefaultSluggableRepository.php
@@ -47,6 +47,6 @@ final class DefaultSluggableRepository implements SluggableRepositoryInterface
         SluggableInterface $newOrUpdated,
         SluggableInterface $exisiting
     ): bool {
-        return $uniqueSlug === $exisiting->getSlug();
+        return $uniqueSlug !== $exisiting->getSlug();
     }
 }

--- a/tests/Fixtures/Entity/SluggableWithUniqenessAndOwnRepositoryEntity.php
+++ b/tests/Fixtures/Entity/SluggableWithUniqenessAndOwnRepositoryEntity.php
@@ -50,17 +50,11 @@ class SluggableWithUniqenessAndOwnRepositoryEntity implements SluggableInterface
         $this->name = $name;
     }
 
-    /**
-     * @return int
-     */
     public function getSlugContext(): int
     {
         return $this->slugContext;
     }
 
-    /**
-     * @param int $slugContext
-     */
     public function setSlugContext(int $slugContext): void
     {
         $this->slugContext = $slugContext;

--- a/tests/Fixtures/Entity/SluggableWithUniqenessAndOwnRepositoryEntity.php
+++ b/tests/Fixtures/Entity/SluggableWithUniqenessAndOwnRepositoryEntity.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Knp\DoctrineBehaviors\Tests\Fixtures\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Knp\DoctrineBehaviors\Contract\Entity\SluggableInterface;
+use Knp\DoctrineBehaviors\Model\Sluggable\SluggableTrait;
+
+/**
+ * @ORM\Entity(repositoryClass="Knp\DoctrineBehaviors\Tests\Fixtures\Repository\SluggableWithUniqenessAndOwnRepositoryRepository")
+ */
+class SluggableWithUniqenessAndOwnRepositoryEntity implements SluggableInterface
+{
+    use SluggableTrait;
+
+    /**
+     * @ORM\Column(type="string")
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @ORM\Column(type="integer")
+     * @var integer
+     */
+    private $slugContext;
+
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     * @var int
+     */
+    private $id;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return int
+     */
+    public function getSlugContext(): int
+    {
+        return $this->slugContext;
+    }
+
+    /**
+     * @param int $slugContext
+     */
+    public function setSlugContext(int $slugContext): void
+    {
+        $this->slugContext = $slugContext;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getSluggableFields(): array
+    {
+        return ['name'];
+    }
+
+    public function shouldGenerateUniqueSlugs(): bool
+    {
+        return true;
+    }
+}

--- a/tests/Fixtures/Repository/SluggableWithUniqenessAndOwnRepositoryRepository.php
+++ b/tests/Fixtures/Repository/SluggableWithUniqenessAndOwnRepositoryRepository.php
@@ -1,0 +1,45 @@
+<?php
+
+
+declare(strict_types=1);
+
+namespace Knp\DoctrineBehaviors\Tests\Fixtures\Repository;
+
+use Doctrine\ORM\EntityRepository;
+use Knp\DoctrineBehaviors\Contract\Entity\SluggableInterface;
+use Knp\DoctrineBehaviors\Contract\Repository\SluggableRepositoryInterface;
+use Knp\DoctrineBehaviors\Tests\Fixtures\Entity\SluggableWithUniqenessAndOwnRepositoryEntity;
+
+final class SluggableWithUniqenessAndOwnRepositoryRepository extends EntityRepository implements SluggableRepositoryInterface
+{
+    public function isSlugUniqueFor(SluggableInterface $sluggable, string $uniqueSlug): bool
+    {
+        $entityClass = get_class($sluggable);
+
+        $queryBuilder = $this->getEntityManager()->createQueryBuilder()
+                                            ->select('e')
+                                            ->from($entityClass, 'e')
+                                            ->select('COUNT(e)')
+                                            ->andWhere('e.slug = :slug')
+                                            ->andWhere('e.slugContext = :slugContext')
+                                            ->setParameter('slug', $uniqueSlug)
+                                            ->setParameter('slugContext', $sluggable->getSlugContext());
+
+        $id = $sluggable->getId();
+        if ($id !== null) {
+            $queryBuilder
+                ->andWhere('e.id != :id')
+                ->setParameter('id', $id);
+        }
+
+        return ! (bool) $queryBuilder->getQuery()->getSingleScalarResult();
+    }
+
+    public function isSlugUnique(string $uniqueSlug, SluggableInterface $newOrUpdated, SluggableInterface $exisiting): bool
+    {
+        if (!$newOrUpdated instanceof SluggableWithUniqenessAndOwnRepositoryEntity || !$exisiting instanceof SluggableWithUniqenessAndOwnRepositoryEntity) {
+            return true;
+        }
+        return ($newOrUpdated->getSlugContext() !== $exisiting->getSlugContext()) || ($uniqueSlug !== $exisiting->getSlug());
+    }
+}

--- a/tests/ORM/SluggableWithUniqenessAndOwnRepositoryTest.php
+++ b/tests/ORM/SluggableWithUniqenessAndOwnRepositoryTest.php
@@ -27,11 +27,11 @@ final class SluggableWithUniqenessAndOwnRepositoryTest extends AbstractBehaviorT
     public function testSlugSameContextSameUnitOfWork(): void
     {
         $entity1 = new SluggableWithUniqenessAndOwnRepositoryEntity();
-        $entity1->setName("Lorem ipsum");
+        $entity1->setName('Lorem ipsum');
         $entity1->setSlugContext(1);
 
         $entity2 = new SluggableWithUniqenessAndOwnRepositoryEntity();
-        $entity2->setName("Lorem ipsum");
+        $entity2->setName('Lorem ipsum');
         $entity2->setSlugContext(1);
 
         $this->entityManager->persist($entity1);
@@ -46,8 +46,8 @@ final class SluggableWithUniqenessAndOwnRepositoryTest extends AbstractBehaviorT
 
         $this->entityManager->clear();
 
-        $entity1   = $this->repository->find($id1);
-        $entity2   = $this->repository->find($id2);
+        $entity1 = $this->repository->find($id1);
+        $entity2 = $this->repository->find($id2);
 
         $this->assertNotNull($entity1);
         $this->assertNotNull($entity2);
@@ -63,11 +63,11 @@ final class SluggableWithUniqenessAndOwnRepositoryTest extends AbstractBehaviorT
     public function testSlugDifferentContextSameUnitOfWork(): void
     {
         $entity1 = new SluggableWithUniqenessAndOwnRepositoryEntity();
-        $entity1->setName("Lorem ipsum");
+        $entity1->setName('Lorem ipsum');
         $entity1->setSlugContext(1);
 
         $entity2 = new SluggableWithUniqenessAndOwnRepositoryEntity();
-        $entity2->setName("Lorem ipsum");
+        $entity2->setName('Lorem ipsum');
         $entity2->setSlugContext(2);
 
         $this->entityManager->persist($entity1);
@@ -82,8 +82,8 @@ final class SluggableWithUniqenessAndOwnRepositoryTest extends AbstractBehaviorT
 
         $this->entityManager->clear();
 
-        $entity1   = $this->repository->find($id1);
-        $entity2   = $this->repository->find($id2);
+        $entity1 = $this->repository->find($id1);
+        $entity2 = $this->repository->find($id2);
 
         $this->assertNotNull($entity1);
         $this->assertNotNull($entity2);
@@ -99,13 +99,13 @@ final class SluggableWithUniqenessAndOwnRepositoryTest extends AbstractBehaviorT
     public function testSlugSameContextDifferentUnitOfWork(): void
     {
         $entity1 = new SluggableWithUniqenessAndOwnRepositoryEntity();
-        $entity1->setName("Lorem ipsum");
+        $entity1->setName('Lorem ipsum');
         $entity1->setSlugContext(1);
         $this->entityManager->persist($entity1);
         $this->entityManager->flush();
 
         $entity2 = new SluggableWithUniqenessAndOwnRepositoryEntity();
-        $entity2->setName("Lorem ipsum");
+        $entity2->setName('Lorem ipsum');
         $entity2->setSlugContext(1);
 
         $this->entityManager->persist($entity2);
@@ -119,8 +119,8 @@ final class SluggableWithUniqenessAndOwnRepositoryTest extends AbstractBehaviorT
 
         $this->entityManager->clear();
 
-        $entity1   = $this->repository->find($id1);
-        $entity2   = $this->repository->find($id2);
+        $entity1 = $this->repository->find($id1);
+        $entity2 = $this->repository->find($id2);
 
         $this->assertNotNull($entity1);
         $this->assertNotNull($entity2);
@@ -136,13 +136,13 @@ final class SluggableWithUniqenessAndOwnRepositoryTest extends AbstractBehaviorT
     public function testSlugDifferentContextDifferentUnitOfWork(): void
     {
         $entity1 = new SluggableWithUniqenessAndOwnRepositoryEntity();
-        $entity1->setName("Lorem ipsum");
+        $entity1->setName('Lorem ipsum');
         $entity1->setSlugContext(1);
         $this->entityManager->persist($entity1);
         $this->entityManager->flush();
 
         $entity2 = new SluggableWithUniqenessAndOwnRepositoryEntity();
-        $entity2->setName("Lorem ipsum");
+        $entity2->setName('Lorem ipsum');
         $entity2->setSlugContext(2);
 
         $this->entityManager->persist($entity2);
@@ -156,8 +156,8 @@ final class SluggableWithUniqenessAndOwnRepositoryTest extends AbstractBehaviorT
 
         $this->entityManager->clear();
 
-        $entity1   = $this->repository->find($id1);
-        $entity2   = $this->repository->find($id2);
+        $entity1 = $this->repository->find($id1);
+        $entity2 = $this->repository->find($id2);
 
         $this->assertNotNull($entity1);
         $this->assertNotNull($entity2);

--- a/tests/ORM/SluggableWithUniqenessAndOwnRepositoryTest.php
+++ b/tests/ORM/SluggableWithUniqenessAndOwnRepositoryTest.php
@@ -1,0 +1,172 @@
+<?php
+
+
+declare(strict_types=1);
+
+namespace Knp\DoctrineBehaviors\Tests\ORM;
+
+use Doctrine\Common\Persistence\ObjectRepository;
+use Doctrine\ORM\EntityRepository;
+use Knp\DoctrineBehaviors\Tests\AbstractBehaviorTestCase;
+use Knp\DoctrineBehaviors\Tests\Fixtures\Entity\SluggableWithUniqenessAndOwnRepositoryEntity;
+
+final class SluggableWithUniqenessAndOwnRepositoryTest extends AbstractBehaviorTestCase
+{
+    /**
+     * @var ObjectRepository|EntityRepository
+     */
+    private $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->repository = $this->entityManager->getRepository(SluggableWithUniqenessAndOwnRepositoryEntity::class);
+    }
+
+    public function testSlugSameContextSameUnitOfWork(): void
+    {
+        $entity1 = new SluggableWithUniqenessAndOwnRepositoryEntity();
+        $entity1->setName("Lorem ipsum");
+        $entity1->setSlugContext(1);
+
+        $entity2 = new SluggableWithUniqenessAndOwnRepositoryEntity();
+        $entity2->setName("Lorem ipsum");
+        $entity2->setSlugContext(1);
+
+        $this->entityManager->persist($entity1);
+        $this->entityManager->persist($entity2);
+        $this->entityManager->flush();
+
+        $id1 = $entity1->getId();
+        $this->assertNotNull($id1);
+
+        $id2 = $entity2->getId();
+        $this->assertNotNull($id2);
+
+        $this->entityManager->clear();
+
+        $entity1   = $this->repository->find($id1);
+        $entity2   = $this->repository->find($id2);
+
+        $this->assertNotNull($entity1);
+        $this->assertNotNull($entity2);
+
+        $this->assertSame('Lorem ipsum', $entity1->getName());
+        $this->assertSame('lorem-ipsum', $entity1->getSlug());
+        $this->assertSame(1, $entity1->getSlugContext());
+        $this->assertSame('Lorem ipsum', $entity2->getName());
+        $this->assertSame('lorem-ipsum-1', $entity2->getSlug());
+        $this->assertSame(1, $entity2->getSlugContext());
+    }
+
+    public function testSlugDifferentContextSameUnitOfWork(): void
+    {
+        $entity1 = new SluggableWithUniqenessAndOwnRepositoryEntity();
+        $entity1->setName("Lorem ipsum");
+        $entity1->setSlugContext(1);
+
+        $entity2 = new SluggableWithUniqenessAndOwnRepositoryEntity();
+        $entity2->setName("Lorem ipsum");
+        $entity2->setSlugContext(2);
+
+        $this->entityManager->persist($entity1);
+        $this->entityManager->persist($entity2);
+        $this->entityManager->flush();
+
+        $id1 = $entity1->getId();
+        $this->assertNotNull($id1);
+
+        $id2 = $entity2->getId();
+        $this->assertNotNull($id2);
+
+        $this->entityManager->clear();
+
+        $entity1   = $this->repository->find($id1);
+        $entity2   = $this->repository->find($id2);
+
+        $this->assertNotNull($entity1);
+        $this->assertNotNull($entity2);
+
+        $this->assertSame('Lorem ipsum', $entity1->getName());
+        $this->assertSame('lorem-ipsum', $entity1->getSlug());
+        $this->assertSame(1, $entity1->getSlugContext());
+        $this->assertSame('Lorem ipsum', $entity2->getName());
+        $this->assertSame('lorem-ipsum', $entity2->getSlug());
+        $this->assertSame(2, $entity2->getSlugContext());
+    }
+
+    public function testSlugSameContextDifferentUnitOfWork(): void
+    {
+        $entity1 = new SluggableWithUniqenessAndOwnRepositoryEntity();
+        $entity1->setName("Lorem ipsum");
+        $entity1->setSlugContext(1);
+        $this->entityManager->persist($entity1);
+        $this->entityManager->flush();
+
+        $entity2 = new SluggableWithUniqenessAndOwnRepositoryEntity();
+        $entity2->setName("Lorem ipsum");
+        $entity2->setSlugContext(1);
+
+        $this->entityManager->persist($entity2);
+        $this->entityManager->flush();
+
+        $id1 = $entity1->getId();
+        $this->assertNotNull($id1);
+
+        $id2 = $entity2->getId();
+        $this->assertNotNull($id2);
+
+        $this->entityManager->clear();
+
+        $entity1   = $this->repository->find($id1);
+        $entity2   = $this->repository->find($id2);
+
+        $this->assertNotNull($entity1);
+        $this->assertNotNull($entity2);
+
+        $this->assertSame('Lorem ipsum', $entity1->getName());
+        $this->assertSame('lorem-ipsum', $entity1->getSlug());
+        $this->assertSame(1, $entity1->getSlugContext());
+        $this->assertSame('Lorem ipsum', $entity2->getName());
+        $this->assertSame('lorem-ipsum-1', $entity2->getSlug());
+        $this->assertSame(1, $entity2->getSlugContext());
+    }
+
+    public function testSlugDifferentContextDifferentUnitOfWork(): void
+    {
+        $entity1 = new SluggableWithUniqenessAndOwnRepositoryEntity();
+        $entity1->setName("Lorem ipsum");
+        $entity1->setSlugContext(1);
+        $this->entityManager->persist($entity1);
+        $this->entityManager->flush();
+
+        $entity2 = new SluggableWithUniqenessAndOwnRepositoryEntity();
+        $entity2->setName("Lorem ipsum");
+        $entity2->setSlugContext(2);
+
+        $this->entityManager->persist($entity2);
+        $this->entityManager->flush();
+
+        $id1 = $entity1->getId();
+        $this->assertNotNull($id1);
+
+        $id2 = $entity2->getId();
+        $this->assertNotNull($id2);
+
+        $this->entityManager->clear();
+
+        $entity1   = $this->repository->find($id1);
+        $entity2   = $this->repository->find($id2);
+
+        $this->assertNotNull($entity1);
+        $this->assertNotNull($entity2);
+
+        $this->assertSame('Lorem ipsum', $entity1->getName());
+        $this->assertSame('lorem-ipsum', $entity1->getSlug());
+        $this->assertSame(1, $entity1->getSlugContext());
+        $this->assertSame('Lorem ipsum', $entity2->getName());
+        $this->assertSame('lorem-ipsum', $entity2->getSlug());
+        $this->assertSame(2, $entity2->getSlugContext());
+    }
+}


### PR DESCRIPTION
Hi!
I'm migrating away from the Gedmo-DoctrineExtension and noticed that there is no equivalent to the unique_base option of Sluggable.
Switching the DefaultSluggableRepository would be fine for my usecase, but that's not possible because the class is marked as final.

I created an interface for the SluggableRepository with the isSlugUniqueFor-Method for checking against the database, and an additional isSlugUnique-Method which is used to check against other entities in the current changeset.

Testcases are provided. :)