### PR TITLE
Package own EventSubscriberInterface 

### DIFF
--- a/src/Bundle/DependencyInjection/DoctrineBehaviorsExtension.php
+++ b/src/Bundle/DependencyInjection/DoctrineBehaviorsExtension.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Knp\DoctrineBehaviors\Bundle\DependencyInjection;
 
-use Doctrine\Common\EventSubscriber;
+use Knp\DoctrineBehaviors\EventSubscriber\EventSubscriberInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
@@ -26,7 +26,7 @@ final class DoctrineBehaviorsExtension extends Extension
         $loader->load('services.yaml');
 
         // @see https://github.com/doctrine/DoctrineBundle/issues/674
-        $containerBuilder->registerForAutoconfiguration(EventSubscriber::class)
+        $containerBuilder->registerForAutoconfiguration(EventSubscriberInterface::class)
             ->addTag(self::DOCTRINE_EVENT_SUBSCRIBER_TAG);
     }
 }

--- a/src/EventSubscriber/BlameableSubscriber.php
+++ b/src/EventSubscriber/BlameableSubscriber.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Knp\DoctrineBehaviors\EventSubscriber;
 
-use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
@@ -14,7 +13,7 @@ use Doctrine\ORM\UnitOfWork;
 use Knp\DoctrineBehaviors\Contract\Entity\BlameableInterface;
 use Knp\DoctrineBehaviors\Contract\Provider\UserProviderInterface;
 
-final class BlameableSubscriber implements EventSubscriber
+final class BlameableSubscriber implements EventSubscriberInterface
 {
     /**
      * @var string

--- a/src/EventSubscriber/EventSubscriberInterface.php
+++ b/src/EventSubscriber/EventSubscriberInterface.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace Knp\DoctrineBehaviors\EventSubscriber;
+
+use Doctrine\Common\EventSubscriber as BaseEventSubscriber;
+
+/**
+ * Interface EventSubscriberInterface to use for auto configuration
+ *
+ * @author Enrico Thies <et@mandarin-medien.de>
+ * @see    https://github.com/doctrine/DoctrineBundle/issues/674
+ */
+interface EventSubscriberInterface extends BaseEventSubscriber
+{
+}

--- a/src/EventSubscriber/EventSubscriberInterface.php
+++ b/src/EventSubscriber/EventSubscriberInterface.php
@@ -8,8 +8,7 @@ use Doctrine\Common\EventSubscriber as BaseEventSubscriber;
 /**
  * Interface EventSubscriberInterface to use for auto configuration
  *
- * @author Enrico Thies <et@mandarin-medien.de>
- * @see    https://github.com/doctrine/DoctrineBundle/issues/674
+ * @see https://github.com/doctrine/DoctrineBundle/issues/674
  */
 interface EventSubscriberInterface extends BaseEventSubscriber
 {

--- a/src/EventSubscriber/LoggableSubscriber.php
+++ b/src/EventSubscriber/LoggableSubscriber.php
@@ -4,14 +4,13 @@ declare(strict_types=1);
 
 namespace Knp\DoctrineBehaviors\EventSubscriber;
 
-use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Events;
 use Knp\DoctrineBehaviors\Contract\Entity\LoggableInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 
-final class LoggableSubscriber implements EventSubscriber
+final class LoggableSubscriber implements EventSubscriberInterface
 {
     /**
      * @var LoggerInterface

--- a/src/EventSubscriber/SluggableSubscriber.php
+++ b/src/EventSubscriber/SluggableSubscriber.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Knp\DoctrineBehaviors\EventSubscriber;
 
-use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
@@ -13,7 +12,7 @@ use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Knp\DoctrineBehaviors\Contract\Entity\SluggableInterface;
 use Knp\DoctrineBehaviors\Repository\DefaultSluggableRepository;
 
-final class SluggableSubscriber implements EventSubscriber
+final class SluggableSubscriber implements EventSubscriberInterface
 {
     /**
      * @var string

--- a/src/EventSubscriber/SoftDeletableSubscriber.php
+++ b/src/EventSubscriber/SoftDeletableSubscriber.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace Knp\DoctrineBehaviors\EventSubscriber;
 
-use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Event\OnFlushEventArgs;
 use Doctrine\ORM\Events;
 use Knp\DoctrineBehaviors\Contract\Entity\SoftDeletableInterface;
 
-final class SoftDeletableSubscriber implements EventSubscriber
+final class SoftDeletableSubscriber implements EventSubscriberInterface
 {
     /**
      * @var string

--- a/src/EventSubscriber/TimestampableSubscriber.php
+++ b/src/EventSubscriber/TimestampableSubscriber.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Knp\DoctrineBehaviors\EventSubscriber;
 
-use Doctrine\Common\EventSubscriber;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\ORM\EntityManagerInterface;
@@ -12,7 +11,7 @@ use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Events;
 use Knp\DoctrineBehaviors\Contract\Entity\TimestampableInterface;
 
-final class TimestampableSubscriber implements EventSubscriber
+final class TimestampableSubscriber implements EventSubscriberInterface
 {
     /**
      * @var EntityManagerInterface

--- a/src/EventSubscriber/TranslatableSubscriber.php
+++ b/src/EventSubscriber/TranslatableSubscriber.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Knp\DoctrineBehaviors\EventSubscriber;
 
-use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Events;
@@ -13,7 +12,7 @@ use Knp\DoctrineBehaviors\Contract\Entity\TranslatableInterface;
 use Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface;
 use Knp\DoctrineBehaviors\Contract\Provider\LocaleProviderInterface;
 
-final class TranslatableSubscriber implements EventSubscriber
+final class TranslatableSubscriber implements EventSubscriberInterface
 {
     /**
      * @var string

--- a/src/EventSubscriber/TreeSubscriber.php
+++ b/src/EventSubscriber/TreeSubscriber.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Knp\DoctrineBehaviors\EventSubscriber;
 
-use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Events;
 use Knp\DoctrineBehaviors\Contract\Entity\TreeNodeInterface;

--- a/src/EventSubscriber/TreeSubscriber.php
+++ b/src/EventSubscriber/TreeSubscriber.php
@@ -8,7 +8,7 @@ use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Events;
 use Knp\DoctrineBehaviors\Contract\Entity\TreeNodeInterface;
 
-final class TreeSubscriber implements EventSubscriber
+final class TreeSubscriber implements EventSubscriberInterface
 {
     public function loadClassMetadata(LoadClassMetadataEventArgs $loadClassMetadataEventArgs): void
     {

--- a/src/EventSubscriber/UuidableSubscriber.php
+++ b/src/EventSubscriber/UuidableSubscriber.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace Knp\DoctrineBehaviors\EventSubscriber;
 
-use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Events;
 use Knp\DoctrineBehaviors\Contract\Entity\UuidableInterface;
 
-final class UuidableSubscriber implements EventSubscriber
+final class UuidableSubscriber implements EventSubscriberInterface
 {
     public function loadClassMetadata(LoadClassMetadataEventArgs $loadClassMetadataEventArgs): void
     {


### PR DESCRIPTION
Created an EventSubscriberInterface and use it when registerForAutoconfiguration doctrine.event_subscriber instead of the using Doctrine\Common\EventSubscriber.

Using Doctrine\Common\EventSubscriber reulted in cache:clear for me to fail