### PR TITLE
fix(phpstan): allow PHPStan to run over Translatable/Translation interfaces, close #588

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -20,6 +20,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/config',
         __DIR__ . '/src',
         __DIR__ . '/tests',
+        __DIR__ . '/utils',
         __DIR__ . '/ecs.php',
         __DIR__ . '/rector-ci.php',
     ]);

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -46,6 +46,8 @@ parameters:
 
         - '#Call to method getUuid\(\) on an unknown class Knp\\DoctrineBehaviors\\Model\\Uuidable\\UuidableTrait#'
 
+        - '#Do not use "\$entityManager->getRepository\(\)" outside of the constructor of repository service#'
+
         # resolve in follow up PR
         - '#Use explicit return value over magic &reference#'
         - '#Class "(.*?)" with static method must have "static" in its name#'

--- a/rector-ci.php
+++ b/rector-ci.php
@@ -11,7 +11,7 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters = $containerConfigurator->parameters();
 
-    $parameters->set(Option::PATHS, [__DIR__ . '/src', __DIR__ . '/tests']);
+    $parameters->set(Option::PATHS, [__DIR__ . '/src', __DIR__ . '/tests', __DIR__ . '/utils']);
 
     $parameters->set(Option::SETS, [
         SetList::DEAD_CODE,

--- a/tests/ORM/TranslatableTest.php
+++ b/tests/ORM/TranslatableTest.php
@@ -272,16 +272,16 @@ final class TranslatableTest extends AbstractBehaviorTestCase
 
     public function testPhpStanExtensionOnInterfaces(): void
     {
-        /** @var TranslationInterface $translationEntity */
-        $translationEntity = new TranslatableEntityTranslation();
-        $translationEntity->setLocale('fr');
+        /** @var TranslationInterface $translatableEntityTranslation */
+        $translatableEntityTranslation = new TranslatableEntityTranslation();
+        $translatableEntityTranslation->setLocale('fr');
 
         /** @var TranslatableInterface $translatableEntity */
         $translatableEntity = new TranslatableEntity();
-        $translatableEntity->addTranslation($translationEntity);
+        $translatableEntity->addTranslation($translatableEntityTranslation);
 
-        $this->assertSame($translatableEntity, $translationEntity->getTranslatable());
-        $this->assertSame($translationEntity, $translatableEntity->getTranslations()->get('fr'));
+        $this->assertSame($translatableEntity, $translatableEntityTranslation->getTranslatable());
+        $this->assertSame($translatableEntityTranslation, $translatableEntity->getTranslations()->get('fr'));
     }
 
     /**

--- a/tests/ORM/TranslatableTest.php
+++ b/tests/ORM/TranslatableTest.php
@@ -7,6 +7,8 @@ namespace Knp\DoctrineBehaviors\Tests\ORM;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\Persistence\ObjectRepository;
+use Knp\DoctrineBehaviors\Contract\Entity\TranslatableInterface;
+use Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface;
 use Knp\DoctrineBehaviors\Tests\AbstractBehaviorTestCase;
 use Knp\DoctrineBehaviors\Tests\Fixtures\Entity\TranslatableCustomizedEntity;
 use Knp\DoctrineBehaviors\Tests\Fixtures\Entity\TranslatableEntity;
@@ -266,6 +268,20 @@ final class TranslatableTest extends AbstractBehaviorTestCase
         $this->assertSame('fabuleux', $entity->translate('fr')->getTitle());
         $this->assertNull($entity->translate('en')->getTitle());
         $this->assertSame('удивительный', $entity->translate('ru')->getTitle());
+    }
+
+    public function testPhpStanExtensionOnInterfaces(): void
+    {
+        /** @var TranslationInterface $translationEntity */
+        $translationEntity = new TranslatableEntityTranslation();
+        $translationEntity->setLocale('fr');
+
+        /** @var TranslatableInterface $translatableEntity */
+        $translatableEntity = new TranslatableEntity();
+        $translatableEntity->addTranslation($translationEntity);
+
+        $this->assertSame($translatableEntity, $translationEntity->getTranslatable());
+        $this->assertSame($translationEntity, $translatableEntity->getTranslations()->get('fr'));
     }
 
     /**

--- a/utils/phpstan-behaviors/src/Type/TranslationTypeHelper.php
+++ b/utils/phpstan-behaviors/src/Type/TranslationTypeHelper.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Knp\DoctrineBehaviors\PHPStan\Type;
 
+use Knp\DoctrineBehaviors\Contract\Entity\TranslatableInterface;
+use Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Broker\Broker;
@@ -14,10 +16,20 @@ final class TranslationTypeHelper
     {
         $type = $scope->getType($methodCall->var);
         $translatableClass = $type->getReferencedClasses()[0];
+        $reflection = $broker->getClass($translatableClass)->getNativeReflection();
 
-        return $broker
-            ->getClass($translatableClass)
-            ->getNativeReflection()
+        if ($reflection->isInterface()) {
+            if ($reflection->getName() === TranslatableInterface::class) {
+                return TranslationInterface::class;
+            }
+
+            throw new \Exception(sprintf(
+                'Unable to find the Translation class associated to the Translatable class "%s".',
+                $reflection->getName()
+            ));
+        }
+
+        return $reflection
             ->getMethod('getTranslationEntityClass')
             ->invoke(null);
     }
@@ -25,11 +37,21 @@ final class TranslationTypeHelper
     public static function getTranslatableClass(Broker $broker, MethodCall $methodCall, Scope $scope): string
     {
         $type = $scope->getType($methodCall->var);
-        $translatableClass = $type->getReferencedClasses()[0];
+        $translationClass = $type->getReferencedClasses()[0];
+        $reflection = $broker->getClass($translationClass)->getNativeReflection();
 
-        return $broker
-            ->getClass($translatableClass)
-            ->getNativeReflection()
+        if ($reflection->isInterface()) {
+            if ($reflection->getName() === TranslationInterface::class) {
+                return TranslatableInterface::class;
+            }
+
+            throw new \Exception(sprintf(
+                'Unable to find the Translatable class associated to the Translation class "%s".',
+                $reflection->getName()
+            ));
+        }
+
+        return $reflection
             ->getMethod('getTranslatableEntityClass')
             ->invoke(null);
     }


### PR DESCRIPTION
Fix #588 

@TomasVotruba There are some PHPStan issues `Do not use "$entityManager->getRepository()" outside of the constructor of repository service` but are not related to this PR. They were already present in master.

I've also configured ECS and Rector to run over `utils` directory. What do you think?