### PR TITLE
Changed "Voilá!" to "voilà!"

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ final class CategoryRepository extends EntityRepository
 }
 ```
 
-Voilá!
+Voilà!
 
 You now have a working `Category` that behaves like.
 


### PR DESCRIPTION
_"voilà"_ is the correct way to write this word in french.