### PR TITLE
feature/fix-bug-with-mapped-superclass

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -40,7 +40,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         PropertyTypeHintSniff::class => null,
         PhpUnitStrictFixer::class => ['tests/ORM/TimestampableTest.php'],
         UnusedPrivateElementsSniff::class => ['tests/Fixtures/Entity/SluggableWithoutRegenerateEntity.php'],
-        FinalClassFixer::class => ['tests/Fixtures/Entity/TimestampableMappedSuperclassEntity.php'],
         OrderedImportsFixer::class => ['tests/Fixtures/Entity/TimestampableMappedSuperclassEntity.php'],
     ]);
 

--- a/ecs.php
+++ b/ecs.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use PhpCsFixer\Fixer\ClassNotation\FinalClassFixer;
 use PhpCsFixer\Fixer\Comment\HeaderCommentFixer;
+use PhpCsFixer\Fixer\Import\OrderedImportsFixer;
 use PhpCsFixer\Fixer\Operator\UnaryOperatorSpacesFixer;
 use PhpCsFixer\Fixer\Phpdoc\GeneralPhpdocAnnotationRemoveFixer;
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitStrictFixer;
@@ -39,6 +40,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         PropertyTypeHintSniff::class => null,
         PhpUnitStrictFixer::class => ['tests/ORM/TimestampableTest.php'],
         UnusedPrivateElementsSniff::class => ['tests/Fixtures/Entity/SluggableWithoutRegenerateEntity.php'],
+        FinalClassFixer::class => ['tests/Fixtures/Entity/TimestampableMappedSuperclassEntity.php'],
+        OrderedImportsFixer::class => ['tests/Fixtures/Entity/TimestampableMappedSuperclassEntity.php'],
     ]);
 
     $parameters->set(Option::EXCLUDE_PATHS, [

--- a/ecs.php
+++ b/ecs.php
@@ -40,7 +40,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         PropertyTypeHintSniff::class => null,
         PhpUnitStrictFixer::class => ['tests/ORM/TimestampableTest.php'],
         UnusedPrivateElementsSniff::class => ['tests/Fixtures/Entity/SluggableWithoutRegenerateEntity.php'],
-        OrderedImportsFixer::class => ['tests/Fixtures/Entity/TimestampableMappedSuperclassEntity.php'],
+        OrderedImportsFixer::class => ['tests/Fixtures/Entity/AbstractTimestampableMappedSuperclassEntity.php'],
     ]);
 
     $parameters->set(Option::EXCLUDE_PATHS, [

--- a/src/EventSubscriber/TimestampableEventSubscriber.php
+++ b/src/EventSubscriber/TimestampableEventSubscriber.php
@@ -33,6 +33,10 @@ final class TimestampableEventSubscriber implements EventSubscriber
             return;
         }
 
+        if ($classMetadata->isMappedSuperclass) {
+            return;
+        }
+
         $classMetadata->addLifecycleCallback('updateTimestamps', Events::prePersist);
         $classMetadata->addLifecycleCallback('updateTimestamps', Events::preUpdate);
 

--- a/tests/Fixtures/Entity/AbstractTimestampableMappedSuperclassEntity.php
+++ b/tests/Fixtures/Entity/AbstractTimestampableMappedSuperclassEntity.php
@@ -12,7 +12,7 @@ use DateTimeInterface;
 /**
  * @ORM\MappedSuperclass
  */
-abstract class TimestampableMappedSuperclassEntity implements TimestampableInterface
+abstract class AbstractTimestampableMappedSuperclassEntity implements TimestampableInterface
 {
     use TimestampableTrait;
 

--- a/tests/Fixtures/Entity/TimestampableInheritedEntity.php
+++ b/tests/Fixtures/Entity/TimestampableInheritedEntity.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Knp\DoctrineBehaviors\Tests\Fixtures\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class TimestampableInheritedEntity extends TimestampableMappedSuperclassEntity
+{
+    /**
+     * @ORM\Column(type="string", nullable=true)
+     * @var string
+     */
+    protected $title;
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+}

--- a/tests/Fixtures/Entity/TimestampableInheritedEntity.php
+++ b/tests/Fixtures/Entity/TimestampableInheritedEntity.php
@@ -9,7 +9,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @ORM\Entity
  */
-class TimestampableInheritedEntity extends TimestampableMappedSuperclassEntity
+class TimestampableInheritedEntity extends AbstractTimestampableMappedSuperclassEntity
 {
     /**
      * @ORM\Column(type="string", nullable=true)

--- a/tests/Fixtures/Entity/TimestampableMappedSuperclassEntity.php
+++ b/tests/Fixtures/Entity/TimestampableMappedSuperclassEntity.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Knp\DoctrineBehaviors\Tests\Fixtures\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Knp\DoctrineBehaviors\Contract\Entity\TimestampableInterface;
+use Knp\DoctrineBehaviors\Model\Timestampable\TimestampableTrait;
+use DateTimeInterface;
+
+/**
+ * @ORM\MappedSuperclass
+ */
+class TimestampableMappedSuperclassEntity implements TimestampableInterface
+{
+    use TimestampableTrait;
+
+    /**
+     * @ORM\Column(type="datetime")
+     * @var DateTimeInterface
+     */
+    protected $createdAt;
+
+    /**
+     * @ORM\Column(type="datetime")
+     * @var DateTimeInterface
+     */
+    protected $updatedAt;
+
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     * @var int
+     */
+    protected $id;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+}

--- a/tests/Fixtures/Entity/TimestampableMappedSuperclassEntity.php
+++ b/tests/Fixtures/Entity/TimestampableMappedSuperclassEntity.php
@@ -12,7 +12,7 @@ use DateTimeInterface;
 /**
  * @ORM\MappedSuperclass
  */
-class TimestampableMappedSuperclassEntity implements TimestampableInterface
+abstract class TimestampableMappedSuperclassEntity implements TimestampableInterface
 {
     use TimestampableTrait;
 

--- a/tests/ORM/TimestampableWithInheritanceTest.php
+++ b/tests/ORM/TimestampableWithInheritanceTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Knp\DoctrineBehaviors\Tests\ORM;
+
+use DateTime;
+use Knp\DoctrineBehaviors\Tests\AbstractBehaviorTestCase;
+use Knp\DoctrineBehaviors\Tests\Fixtures\Entity\TimestampableInheritedEntity;
+
+final class TimestampableWithInheritanceTest extends AbstractBehaviorTestCase
+{
+    public function testItShouldInitializeCreateAndUpdateDatetimeWhenCreated(): void
+    {
+        $timestampableInheritedEntity = new TimestampableInheritedEntity();
+
+        $this->entityManager->persist($timestampableInheritedEntity);
+        $this->entityManager->flush();
+
+        self::assertInstanceOf(Datetime::class, $timestampableInheritedEntity->getCreatedAt());
+        self::assertInstanceOf(Datetime::class, $timestampableInheritedEntity->getUpdatedAt());
+        self::assertSame(
+            $timestampableInheritedEntity->getCreatedAt(),
+            $timestampableInheritedEntity->getUpdatedAt(),
+            'On creation, createdAt and updatedAt are the same'
+        );
+    }
+}


### PR DESCRIPTION
- fixed bug with MappedSuperclass

If class has `MappedSuperclass` annotation and inherited from `class  implements TimestampableInterface` - we will got the following error:
`Duplicate definition of column 'created_at' on entity in a field or discriminator column mapping.` The same for updatedAt field. Pls have a look to fix.