### PR TITLE
Fixed problem with symfony 5.2-RC1

### DIFF
--- a/src/Provider/UserProvider.php
+++ b/src/Provider/UserProvider.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Knp\DoctrineBehaviors\Provider;
 
 use Knp\DoctrineBehaviors\Contract\Provider\UserProviderInterface;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 final class UserProvider implements UserProviderInterface
 {
@@ -15,19 +15,19 @@ final class UserProvider implements UserProviderInterface
     private $blameableUserEntity;
 
     /**
-     * @var Security
+     * @var TokenStorageInterface
      */
-    private $security;
+    private $tokenStorage;
 
-    public function __construct(Security $security, ?string $blameableUserEntity = null)
+    public function __construct(TokenStorageInterface $tokenStorage, ?string $blameableUserEntity = null)
     {
-        $this->security = $security;
+        $this->tokenStorage = $tokenStorage;
         $this->blameableUserEntity = $blameableUserEntity;
     }
 
     public function provideUser()
     {
-        $token = $this->security->getToken();
+        $token = $this->tokenStorage->getToken();
         if ($token !== null) {
             $user = $token->getUser();
             if ($this->blameableUserEntity) {

--- a/tests/config/config_test.yaml
+++ b/tests/config/config_test.yaml
@@ -13,7 +13,6 @@ services:
         public: true
         autowire: true
 
-    Symfony\Component\Security\Core\Security: null
     Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage: null
     Psr\Log\Test\TestLogger: null
 

--- a/tests/config/config_test.yaml
+++ b/tests/config/config_test.yaml
@@ -14,6 +14,7 @@ services:
         autowire: true
 
     Symfony\Component\Security\Core\Security: null
+    Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage: null
     Psr\Log\Test\TestLogger: null
 
     # for translatable
@@ -23,6 +24,9 @@ services:
     # for blameable
     Knp\DoctrineBehaviors\Tests\Provider\TestUserProvider: null
     Knp\DoctrineBehaviors\Contract\Provider\UserProviderInterface: '@Knp\DoctrineBehaviors\Tests\Provider\TestUserProvider'
+    Knp\DoctrineBehaviors\Provider\UserProvider:
+        arguments:
+            $tokenStorage: '@Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage'
 
     Knp\DoctrineBehaviors\Tests\DatabaseLoader:  null
 


### PR DESCRIPTION
Fixed problem with circular dependency injection after install on symfony 5.2-RC1

> Executing script cache:clear [KO]
 [KO]
Script cache:clear returned with error code 255
!!  Error {#5285
!!    #message: "Maximum function nesting level of '256' reached, aborting!"
!!    #code: 0
!!    #file: "./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php"
!!    #line: 317
!!    trace: {
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:317 {
!!        ContainerUzwxCLB\App_KernelDevDebugContainer->load($file, $lazyLoad = true)
!!        › {
!!        ›     if (class_exists($class = __NAMESPACE__.'\\'.$file, false)) {
!!        ›         return $class::do($this, $lazyLoad);
!!      }
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Orm_DefaultEntityManagerService.php:51 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getBlameableEventSubscriberService.php:29 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Dbal_DefaultConnectionService.php:35 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Orm_DefaultEntityManagerService.php:51 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getBlameableEventSubscriberService.php:29 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Dbal_DefaultConnectionService.php:35 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Orm_DefaultEntityManagerService.php:51 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getBlameableEventSubscriberService.php:29 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Dbal_DefaultConnectionService.php:35 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Orm_DefaultEntityManagerService.php:51 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getBlameableEventSubscriberService.php:29 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Dbal_DefaultConnectionService.php:35 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Orm_DefaultEntityManagerService.php:51 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getBlameableEventSubscriberService.php:29 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Dbal_DefaultConnectionService.php:35 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Orm_DefaultEntityManagerService.php:51 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getBlameableEventSubscriberService.php:29 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Dbal_DefaultConnectionService.php:35 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Orm_DefaultEntityManagerService.php:51 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getBlameableEventSubscriberService.php:29 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Dbal_DefaultConnectionService.php:35 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Orm_DefaultEntityManagerService.php:51 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getBlameableEventSubscriberService.php:29 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Dbal_DefaultConnectionService.php:35 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Orm_DefaultEntityManagerService.php:51 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getBlameableEventSubscriberService.php:29 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Dbal_DefaultConnectionService.php:35 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Orm_DefaultEntityManagerService.php:51 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getBlameableEventSubscriberService.php:29 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Dbal_DefaultConnectionService.php:35 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Orm_DefaultEntityManagerService.php:51 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getBlameableEventSubscriberService.php:29 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Dbal_DefaultConnectionService.php:35 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Orm_DefaultEntityManagerService.php:51 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getBlameableEventSubscriberService.php:29 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Dbal_DefaultConnectionService.php:35 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Orm_DefaultEntityManagerService.php:51 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getBlameableEventSubscriberService.php:29 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Dbal_DefaultConnectionService.php:35 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Orm_DefaultEntityManagerService.php:51 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getBlameableEventSubscriberService.php:29 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Dbal_DefaultConnectionService.php:35 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Orm_DefaultEntityManagerService.php:51 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getBlameableEventSubscriberService.php:29 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Dbal_DefaultConnectionService.php:35 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Orm_DefaultEntityManagerService.php:51 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getBlameableEventSubscriberService.php:29 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Dbal_DefaultConnectionService.php:35 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Orm_DefaultEntityManagerService.php:51 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getBlameableEventSubscriberService.php:29 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Dbal_DefaultConnectionService.php:35 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Orm_DefaultEntityManagerService.php:51 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getBlameableEventSubscriberService.php:29 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Dbal_DefaultConnectionService.php:35 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Orm_DefaultEntityManagerService.php:51 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getBlameableEventSubscriberService.php:29 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Dbal_DefaultConnectionService.php:35 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Orm_DefaultEntityManagerService.php:51 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getBlameableEventSubscriberService.php:29 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Dbal_DefaultConnectionService.php:35 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Orm_DefaultEntityManagerService.php:51 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getBlameableEventSubscriberService.php:29 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Dbal_DefaultConnectionService.php:35 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Orm_DefaultEntityManagerService.php:51 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getBlameableEventSubscriberService.php:29 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Dbal_DefaultConnectionService.php:35 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Orm_DefaultEntityManagerService.php:51 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getBlameableEventSubscriberService.php:29 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Dbal_DefaultConnectionService.php:35 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Orm_DefaultEntityManagerService.php:51 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getBlameableEventSubscriberService.php:29 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Dbal_DefaultConnectionService.php:35 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Orm_DefaultEntityManagerService.php:51 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getBlameableEventSubscriberService.php:29 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Dbal_DefaultConnectionService.php:35 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Orm_DefaultEntityManagerService.php:51 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getBlameableEventSubscriberService.php:29 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Dbal_DefaultConnectionService.php:35 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Orm_DefaultEntityManagerService.php:51 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getBlameableEventSubscriberService.php:29 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Dbal_DefaultConnectionService.php:35 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Orm_DefaultEntityManagerService.php:51 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getBlameableEventSubscriberService.php:29 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Dbal_DefaultConnectionService.php:35 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Orm_DefaultEntityManagerService.php:51 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getBlameableEventSubscriberService.php:29 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Dbal_DefaultConnectionService.php:35 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Orm_DefaultEntityManagerService.php:51 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getBlameableEventSubscriberService.php:29 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Dbal_DefaultConnectionService.php:35 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Orm_DefaultEntityManagerService.php:51 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getBlameableEventSubscriberService.php:29 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Dbal_DefaultConnectionService.php:35 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Orm_DefaultEntityManagerService.php:51 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getBlameableEventSubscriberService.php:29 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Dbal_DefaultConnectionService.php:35 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Orm_DefaultEntityManagerService.php:51 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getBlameableEventSubscriberService.php:29 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Dbal_DefaultConnectionService.php:35 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Orm_DefaultEntityManagerService.php:51 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getBlameableEventSubscriberService.php:29 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Dbal_DefaultConnectionService.php:35 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Orm_DefaultEntityManagerService.php:51 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getBlameableEventSubscriberService.php:29 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Dbal_DefaultConnectionService.php:35 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Orm_DefaultEntityManagerService.php:51 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getBlameableEventSubscriberService.php:29 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Dbal_DefaultConnectionService.php:35 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Orm_DefaultEntityManagerService.php:51 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getBlameableEventSubscriberService.php:29 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Dbal_DefaultConnectionService.php:35 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Orm_DefaultEntityManagerService.php:51 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getBlameableEventSubscriberService.php:29 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Dbal_DefaultConnectionService.php:35 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Orm_DefaultEntityManagerService.php:51 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getBlameableEventSubscriberService.php:29 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Dbal_DefaultConnectionService.php:35 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Orm_DefaultEntityManagerService.php:51 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:318 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getBlameableEventSubscriberService.php:29 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:329 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Dbal_DefaultConnectionService.php:35 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:329 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/getDoctrine_Orm_DefaultEntityManagerService.php:51 { …}
!!      ./var/cache/dev/ContainerUzwxCLB/App_KernelDevDebugContainer.php:329 { …}
!!      ./vendor/symfony/dependency-injection/Container.php:246 { …}
!!      ./vendor/symfony/dependency-injection/Container.php:228 { …}
!!      ./vendor/symfony/doctrine-bridge/ManagerRegistry.php:38 { …}
!!      ./vendor/doctrine/persistence/lib/Doctrine/Persistence/AbstractManagerRegistry.php:205 { …}
!!      ./vendor/symfony/doctrine-bridge/CacheWarmer/ProxyCacheWarmer.php:52 { …}
!!      ./vendor/symfony/http-kernel/CacheWarmer/CacheWarmerAggregate.php:98 { …}
!!      ./vendor/symfony/http-kernel/Kernel.php:580 { …}
!!      ./vendor/symfony/http-kernel/Kernel.php:780 { …}
!!      ./vendor/symfony/http-kernel/Kernel.php:121 { …}
!!      ./vendor/symfony/framework-bundle/Console/Application.php:168 { …}
!!      ./vendor/symfony/framework-bundle/Console/Application.php:74 { …}
!!      ./vendor/symfony/console/Application.php:166 { …}
!!      ./bin/console:43 { …}
!!    }
!!  }
!!  2020-11-16T10:37:03+01:00 [critical] Uncaught Error: Maximum function nesting level of '256' reached, aborting!
!!  
Script @auto-scripts was called via post-update-cmd
