### PR TITLE
Update .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,16 @@
-.gitattributes     export-ignore
-.gitignore         export-ignore
-.travis.yml        export-ignore
-CODE_OF_CONDUCT.md export-ignore
-README.md          export-ignore
-docs               export-ignore
-tests              export-ignore
+* text=auto
+
+/.github                export-ignore
+/docs                   export-ignore
+/tests                  export-ignore
+/utils                  export-ignore
+/.editorconfig          export-ignore
+/.gitattributes         export-ignore
+/.gitignore             export-ignore
+/.kodiak.toml           export-ignore
+/CODE_OF_CONDUCT.md     export-ignore
+/ecs.php                export-ignore
+/phpstan.neon           export-ignore
+/phpstan-extension.neon export-ignore
+/phpunit.xml            export-ignore
+/rector.php             export-ignore


### PR DESCRIPTION
These folders and files are not needed when fetching the package through Composer.

However, i'm not sure about the **utils** folder and **phpstan-extension.neon**.