### PR TITLE
Make Sluggable getter and setter nullable

### DIFF
--- a/src/Contract/Entity/SluggableInterface.php
+++ b/src/Contract/Entity/SluggableInterface.php
@@ -13,9 +13,9 @@ interface SluggableInterface
      */
     public function getSluggableFields(): array;
 
-    public function setSlug(string $slug): void;
+    public function setSlug(?string $slug): void;
 
-    public function getSlug(): string;
+    public function getSlug(): ?string;
 
     /**
      * Generates and sets the entity's slug

--- a/src/Model/Sluggable/SluggableMethodsTrait.php
+++ b/src/Model/Sluggable/SluggableMethodsTrait.php
@@ -9,12 +9,12 @@ use Symfony\Component\String\Slugger\AsciiSlugger;
 
 trait SluggableMethodsTrait
 {
-    public function setSlug(string $slug): void
+    public function setSlug(?string $slug): void
     {
         $this->slug = $slug;
     }
 
-    public function getSlug(): string
+    public function getSlug(): ?string
     {
         return $this->slug;
     }


### PR DESCRIPTION
It resolve the bug `Expected argument of type "string", "null" given at property path "slug".` when you use Sonata Admin.