### PR TITLE
Sluggable + Translation - Allow getters to return null

### DIFF
--- a/src/Contract/Entity/SluggableInterface.php
+++ b/src/Contract/Entity/SluggableInterface.php
@@ -13,9 +13,9 @@ interface SluggableInterface
      */
     public function getSluggableFields(): array;
 
-    public function setSlug(string $slug): void;
+    public function setSlug(?string $slug): void;
 
-    public function getSlug(): string;
+    public function getSlug(): ?string;
 
     /**
      * Generates and sets the entity's slug

--- a/src/Contract/Entity/TranslationInterface.php
+++ b/src/Contract/Entity/TranslationInterface.php
@@ -12,9 +12,9 @@ interface TranslationInterface
 
     public function getTranslatable(): TranslatableInterface;
 
-    public function setLocale(string $locale): void;
+    public function setLocale(?string $locale): void;
 
-    public function getLocale(): string;
+    public function getLocale(): ?string;
 
     public function isEmpty(): bool;
 }

--- a/src/Model/Sluggable/SluggableMethodsTrait.php
+++ b/src/Model/Sluggable/SluggableMethodsTrait.php
@@ -9,12 +9,12 @@ use Symfony\Component\String\Slugger\AsciiSlugger;
 
 trait SluggableMethodsTrait
 {
-    public function setSlug(string $slug): void
+    public function setSlug(?string $slug): void
     {
         $this->slug = $slug;
     }
 
-    public function getSlug(): string
+    public function getSlug(): ?string
     {
         return $this->slug;
     }

--- a/src/Model/Translatable/TranslationMethodsTrait.php
+++ b/src/Model/Translatable/TranslationMethodsTrait.php
@@ -31,12 +31,12 @@ trait TranslationMethodsTrait
         return $this->translatable;
     }
 
-    public function setLocale(string $locale): void
+    public function setLocale(?string $locale): void
     {
         $this->locale = $locale;
     }
 
-    public function getLocale(): string
+    public function getLocale(): ?string
     {
         return $this->locale;
     }


### PR DESCRIPTION
Allow new/empty translatable and sluggable objects to be used in forms, without throwing errors.

The error displayed was :
`Return value of My\Projet\Entity\EntityTranslation::getLocale() must be of the type string, null returned`

We noticed  #640 after making this commit, so we can remove all modifications to Sluggable to avoid any duplicate if needed.