### PR TITLE
fix: betterreflection not returning  native reflection

### DIFF
--- a/utils/phpstan-behaviors/src/Type/TranslationTypeHelper.php
+++ b/utils/phpstan-behaviors/src/Type/TranslationTypeHelper.php
@@ -17,8 +17,7 @@ final class TranslationTypeHelper
     {
         $type = $scope->getType($methodCall->var);
         $translatableClass = $type->getReferencedClasses()[0];
-        $reflectionClass = $broker->getClass($translatableClass)
-            ->getNativeReflection();
+        $reflectionClass = new \ReflectionClass($translatableClass);
 
         if ($reflectionClass->isInterface()) {
             if ($reflectionClass->getName() === TranslatableInterface::class) {


### PR DESCRIPTION
I had this issue but I didn't understand why it happens. But sometimes, [the better reflection used by phpstan](https://github.com/ondrejmirtes/BetterReflection) returns something else (an instance of [this class](https://github.com/ondrejmirtes/BetterReflection/blob/master/src/Reflection/Adapter/ReflectionClass.php)) than a native ReflectionClass. This makes the extension crash.

The fix I managed to make is this one. It just works.


The error:

```
Uncaught ReflectionException: Method of class App\Entity\Translations\TranslatableMethodsTrait cannot be used as the class is not loaded in phar:///xxx/vendor/phpstan/phpstan/phpstan.phar/vendor/ondrejmirtes/better-reflection/src/Reflection/Adapter/ReflectionMethod.php:309
#0 /xxx/config/phpstan/phpstan-behaviors/src/Type/TranslationTypeHelper.php(37): PHPStan\BetterReflection\Reflection\Adapter\ReflectionMethod->invoke(NULL)
#1 /xxx/config/phpstan/phpstan-behaviors/src/Type/TranslatableGetTranslationsDynamicMethodReturnTypeExtension.php(49):Knp\DoctrineBehaviors\PHPStan\Type\TranslationTypeHelper::getTranslationClass(Object(PHPStan\Broker\Broker), Object(PhpParser\Node\Expr\MethodCall), Object(PHPStan\Analyser\MutatingScope))
#2 phar:///xxx/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/MutatingScope.php(3171): Knp\DoctrineBehaviors\PHPStan\Type\TranslatableGetTranslationsDynamicMethodReturnTypeExtension->getTypeFromMethodCall(Object(PHPStan\Reflection\ResolvedMethodReflection), Object(PhpParser\Node\Expr\MethodCall), Object(PHPStan\Analyser\MutatingScope))
```