### PR TITLE
fix isEmpty on zero string value

### DIFF
--- a/src/Model/Translatable/TranslationMethodsTrait.php
+++ b/src/Model/Translatable/TranslationMethodsTrait.php
@@ -48,6 +48,10 @@ trait TranslationMethodsTrait
                 continue;
             }
 
+            if (is_string($value) && strlen(trim($value)) > 0) {
+                return false;
+            }
+
             if (! empty($value)) {
                 return false;
             }


### PR DESCRIPTION
if $value is '0' then the translation is considered as empty