### PR TITLE
use ClassMetadataInfo to determine the referencedColumnName

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -36,6 +36,7 @@ parameters:
         - '#has no return typehint specified#'
         - '#return type has no value type specified#'
         - '#has parameter (.*?) with no (typehint|value type) specified#'
+        - '#Unable to resolve the template type T#'
         # cache buggy
         - '#Access to an undefined property Knp\\DoctrineBehaviors\\Tests\\Fixtures\\Entity\\TreeNodeEntity\:\:\$parentNodePath#'
         - '#Property with protected modifier is not allowed\. Use interface contract method instead#'

--- a/tests/Fixtures/Entity/TranslatableCustomIdentifierEntity.php
+++ b/tests/Fixtures/Entity/TranslatableCustomIdentifierEntity.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Knp\DoctrineBehaviors\Tests\Fixtures\Entity;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Knp\DoctrineBehaviors\Contract\Entity\TranslatableInterface;
+use Knp\DoctrineBehaviors\Model\Translatable\TranslatableTrait;
+
+#[Entity]
+class TranslatableCustomIdentifierEntity implements TranslatableInterface
+{
+    use TranslatableTrait;
+
+    #[Id]
+    #[Column(type: 'integer')]
+    #[GeneratedValue(strategy: 'AUTO')]
+    private int $idColumn;
+
+    public function __call($method, $arguments)
+    {
+        return $this->proxyCurrentLocaleTranslation($method, $arguments);
+    }
+
+    public function getIdColumn(): int
+    {
+        return $this->idColumn;
+    }
+}

--- a/tests/Fixtures/Entity/TranslatableCustomIdentifierEntityTranslation.php
+++ b/tests/Fixtures/Entity/TranslatableCustomIdentifierEntityTranslation.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Knp\DoctrineBehaviors\Tests\Fixtures\Entity;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface;
+use Knp\DoctrineBehaviors\Model\Translatable\TranslationTrait;
+
+#[Entity]
+class TranslatableCustomIdentifierEntityTranslation implements TranslationInterface
+{
+    use TranslationTrait;
+
+    #[Id]
+    #[Column(type: 'integer')]
+    #[GeneratedValue(strategy: 'AUTO')]
+    private int $id;
+
+    #[Column(type: 'string')]
+    private ?string $title = null;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+}

--- a/tests/ORM/Translatable/TranslatableTest.php
+++ b/tests/ORM/Translatable/TranslatableTest.php
@@ -9,6 +9,7 @@ use Doctrine\Persistence\ObjectRepository;
 use Knp\DoctrineBehaviors\Contract\Entity\TranslatableInterface;
 use Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface;
 use Knp\DoctrineBehaviors\Tests\AbstractBehaviorTestCase;
+use Knp\DoctrineBehaviors\Tests\Fixtures\Entity\TranslatableCustomIdentifierEntity;
 use Knp\DoctrineBehaviors\Tests\Fixtures\Entity\TranslatableCustomizedEntity;
 use Knp\DoctrineBehaviors\Tests\Fixtures\Entity\TranslatableEntity;
 use Knp\DoctrineBehaviors\Tests\Fixtures\Entity\TranslatableEntityTranslation;
@@ -51,6 +52,25 @@ final class TranslatableTest extends AbstractBehaviorTestCase
         $this->assertSame('fabuleux', $translatableEntity->translate('fr')->getTitle());
         $this->assertSame('awesome', $translatableEntity->translate('en')->getTitle());
         $this->assertSame('удивительный', $translatableEntity->translate('ru')->getTitle());
+    }
+
+    public function testShouldPersistWithCustomIdentifier(): void
+    {
+        $translatableEntity = new TranslatableCustomIdentifierEntity();
+        $translatableEntity->translate('en')
+            ->setTitle('awesome');
+        $translatableEntity->mergeNewTranslations();
+
+        $this->entityManager->persist($translatableEntity);
+        $this->entityManager->flush();
+
+        $id = $translatableEntity->getIdColumn();
+        $this->entityManager->clear();
+
+        /** @var TranslatableEntity $translatableEntity */
+        $translatableEntity = $this->entityManager->getRepository(TranslatableCustomIdentifierEntity::class)->find($id);
+
+        $this->assertSame('awesome', $translatableEntity->translate('en')->getTitle());
     }
 
     public function testShouldFallbackCountryLocaleToLanguageOnlyTranslation(): void


### PR DESCRIPTION
In case you want to use something else then 'id'.

Is it also possible to make a 2.2.1 release for php 7 support if this is approved?