### PR TITLE
Improve phpdoc of TranslatablePropertiesTrait

### DIFF
--- a/src/Model/Translatable/TranslatablePropertiesTrait.php
+++ b/src/Model/Translatable/TranslatablePropertiesTrait.php
@@ -10,13 +10,13 @@ use Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface;
 trait TranslatablePropertiesTrait
 {
     /**
-     * @var TranslationInterface[]|Collection
+     * @var Collection<TranslationInterface>
      */
     protected $translations;
 
     /**
      * @see mergeNewTranslations
-     * @var TranslationInterface[]|Collection
+     * @var Collection<TranslationInterface>
      */
     protected $newTranslations;
 


### PR DESCRIPTION
`Collection<TranslationInterface>` should be preferred over `TranslationInterface[]|Collection`