### PR TITLE
Fix Collection template usages

### DIFF
--- a/src/Contract/Entity/TranslatableInterface.php
+++ b/src/Contract/Entity/TranslatableInterface.php
@@ -9,12 +9,12 @@ use Doctrine\Common\Collections\Collection;
 interface TranslatableInterface
 {
     /**
-     * @return Collection<TranslationInterface>
+     * @return Collection<string, TranslationInterface>
      */
     public function getTranslations();
 
     /**
-     * @return Collection<TranslationInterface>
+     * @return Collection<string, TranslationInterface>
      */
     public function getNewTranslations(): Collection;
 

--- a/src/Model/Translatable/TranslatableMethodsTrait.php
+++ b/src/Model/Translatable/TranslatableMethodsTrait.php
@@ -12,7 +12,7 @@ use Knp\DoctrineBehaviors\Exception\TranslatableException;
 trait TranslatableMethodsTrait
 {
     /**
-     * @return Collection<TranslationInterface>
+     * @return Collection<string, TranslationInterface>
      */
     public function getTranslations()
     {
@@ -25,7 +25,7 @@ trait TranslatableMethodsTrait
     }
 
     /**
-     * @param Collection<TranslationInterface> $translations
+     * @param Collection<string, TranslationInterface> $translations
      * @phpstan-param iterable<TranslationInterface> $translations
      */
     public function setTranslations(iterable $translations): void
@@ -38,7 +38,7 @@ trait TranslatableMethodsTrait
     }
 
     /**
-     * @return Collection<TranslationInterface>
+     * @return Collection<string, TranslationInterface>
      */
     public function getNewTranslations(): Collection
     {

--- a/src/Model/Translatable/TranslatablePropertiesTrait.php
+++ b/src/Model/Translatable/TranslatablePropertiesTrait.php
@@ -10,13 +10,13 @@ use Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface;
 trait TranslatablePropertiesTrait
 {
     /**
-     * @var Collection<TranslationInterface>
+     * @var Collection<string, TranslationInterface>
      */
     protected $translations;
 
     /**
      * @see mergeNewTranslations
-     * @var Collection<TranslationInterface>
+     * @var Collection<string, TranslationInterface>
      */
     protected $newTranslations;
 


### PR DESCRIPTION
When using [Collection](https://github.com/doctrine/collections/blob/42a111afab917a328fdc38a35101c089ce52b580/lib/Doctrine/Common/Collections/Collection.php#L27-L32), it need to specify the type of the key.

In case of `Translatable` the key is the locale:

https://github.com/KnpLabs/DoctrineBehaviors/blob/a6a4bf3b118137de11b9913a76c58ae89f68c307/src/Model/Translatable/TranslatableMethodsTrait.php#L55-L57