### PR TITLE
Update BlameableEventSubscriber.php

### DIFF
--- a/src/EventSubscriber/BlameableEventSubscriber.php
+++ b/src/EventSubscriber/BlameableEventSubscriber.php
@@ -131,7 +131,7 @@ final class BlameableEventSubscriber implements EventSubscriberInterface
             ->propertyChanged($entity, self::DELETED_BY, $oldValue, $user);
     }
 
-    public function getSubscribedEvents()
+    public function getSubscribedEvents(): array
     {
         return [Events::prePersist, Events::preUpdate, Events::preRemove, Events::loadClassMetadata];
     }


### PR DESCRIPTION
👋 

This PR fixes deprecation on doctrine bundle.

``` 
1x: Method "Doctrine\Common\EventSubscriber::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Knp\DoctrineBehaviors\EventSubscriber\BlameableEventSubscriber" now to avoid errors or add an explicit @return annotation to suppress this message.
``` 

Please let me know if I missed something, I'd be glad to help.