### PR TITLE
Translatable documentation update

### DIFF
--- a/docs/translatable-api-platform.md
+++ b/docs/translatable-api-platform.md
@@ -1,0 +1,113 @@
+# Translatable - API Platform 
+
+How to use Translatable with API platform. 
+
+
+Let's say you have a Document Entity like so: 
+
+Please note: you don't have a `title` property in this entity, we are accessing the `DocumentTranslation` via the `TranslatableInterface` 
+
+```
+use Knp\DoctrineBehaviors\Contract\Entity\TranslatableInterface;
+use Knp\DoctrineBehaviors\Model\Translatable\TranslatableTrait;
+
+class Document implements TranslatableInterface
+{
+use TranslatableTrait;
+
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private ?int $id = null;
+
+    public function getTitle(): string
+    {
+        return $this->translate()
+            ->getTitle();
+    }
+}
+```
+
+Then in the DocumentTranslation entity: 
+
+```
+use Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface;
+use Knp\DoctrineBehaviors\Model\Translatable\TranslationTrait;
+
+#[ORM\Entity]
+class DocumentTranslation implements TranslationInterface
+{
+    use TranslationTrait;
+
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private int $id;
+
+    #[ORM\Column(type: 'string', length: 255)]
+    private string $title;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+}
+```
+
+Now we can implement an Event Subscriber to listen to the accept-language header on each request:
+
+```
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events\Subscribers;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\HeaderUtils;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class LocaleSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @return array<string, array<int[]|string[]>>
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => [['onKernelRequest', 20]],
+        ];
+    }
+
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        $request = $event->getRequest();
+        $acceptLanguage = $request->headers->get('accept-language');
+        if (empty($acceptLanguage)) {
+            return;
+        }
+
+        $arr = HeaderUtils::split($acceptLanguage, ',;');
+        if (empty($arr[0][0])) {
+            return;
+        }
+
+        // Symfony expects underscore instead of dash in locale
+        $locale = str_replace('-', '_', $arr[0][0]);
+
+        $request->setLocale($locale);
+    }
+}
+```
+
+
+Now we can make a request to `/api/documents.json` do not for get to add the `Accept-Language` header value.
+When you change the `Accept-Language` header value, notice the title change language. 
+
+That's it!

--- a/docs/translatable-api-platform.md
+++ b/docs/translatable-api-platform.md
@@ -1,13 +1,13 @@
-# Translatable - API Platform 
+# Translatable - API Platform
 
-How to use Translatable with API platform. 
+How to use Translatable with API platform.
 
+Let's say you have a Document Entity like so:
 
-Let's say you have a Document Entity like so: 
+Please note: you don't have a `title` property in this entity, however it has a getter for it, we are accessing the `DocumentTranslation` via
+the `TranslatableMethodsTrait` you can do this for all the translatable properties.
 
-Please note: you don't have a `title` property in this entity, we are accessing the `DocumentTranslation` via the `TranslatableMethodsTrait` 
-
-```
+```php
 use Knp\DoctrineBehaviors\Contract\Entity\TranslatableInterface;
 use Knp\DoctrineBehaviors\Model\Translatable\TranslatableTrait;
 
@@ -28,9 +28,9 @@ use TranslatableTrait;
 }
 ```
 
-Then in the DocumentTranslation entity: 
+Then in the DocumentTranslation entity:
 
-```
+```php
 use Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface;
 use Knp\DoctrineBehaviors\Model\Translatable\TranslationTrait;
 
@@ -61,7 +61,7 @@ class DocumentTranslation implements TranslationInterface
 
 Now we can implement an Event Subscriber to listen to the accept-language header on each request:
 
-```
+```php
 <?php
 
 declare(strict_types=1);
@@ -106,8 +106,27 @@ class LocaleSubscriber implements EventSubscriberInterface
 }
 ```
 
+Now we can make a request to `/api/documents` do not for get to add the `Accept-Language` header value, in this case it's set to 'cz'. 
+When you change the `Accept-Language` header value, notice the title change language.
 
-Now we can make a request to `/api/documents.json` do not for get to add the `Accept-Language` header value.
-When you change the `Accept-Language` header value, notice the title change language. 
+```json
+{
+  "@context": "/api/contexts/Document",
+  "@id": "/api/documents",
+  "@type": "hydra:Collection",
+  "hydra:member": [
+    {
+      "@id": "/api/documents/1",
+      "@type": "Document",
+      "id": 1,
+      "newTranslations": [],
+      "currentLocale": "cz",
+      "defaultLocale": "en",
+      "title": "příkladová data",
+      "translationEntityClass": "App\\Entity\\DocumentTranslation"
+    }
+  ]
+}
+```
 
 That's it!

--- a/docs/translatable-api-platform.md
+++ b/docs/translatable-api-platform.md
@@ -5,7 +5,7 @@ How to use Translatable with API platform.
 
 Let's say you have a Document Entity like so: 
 
-Please note: you don't have a `title` property in this entity, we are accessing the `DocumentTranslation` via the `TranslatableInterface` 
+Please note: you don't have a `title` property in this entity, we are accessing the `DocumentTranslation` via the `TranslatableMethodsTrait` 
 
 ```
 use Knp\DoctrineBehaviors\Contract\Entity\TranslatableInterface;

--- a/docs/translatable.md
+++ b/docs/translatable.md
@@ -8,9 +8,12 @@ same folder, e.g.:
 
 The default naming convention (or its customization via trait methods) avoids you to manually handle entity associations. It is handled automatically by the `TranslatableEventSubscriber`.
 
+[How to use translatable with api platform?](/docs/translatable-api-platform.md)
+
 ## Entity
 
-You need to add their own id and translatable fields.
+This entity must implement Translation interface, use the Translation trait and have an id. 
+This entity contains the fields you want to be translatable.
 
 ```php
 <?php
@@ -23,43 +26,25 @@ use Doctrine\ORM\Mapping as ORM;
 use Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface;
 use Knp\DoctrineBehaviors\Model\Translatable\TranslationTrait;
 
-/**
- * @ORM\Entity
- */
+#[ORM\Entity]
 class CategoryTranslation implements TranslationInterface
 {
     use TranslationTrait;
 
-    /**
-     * @ORM\Id
-     * @ORM\Column(type="integer")
-     * @ORM\GeneratedValue(strategy="AUTO")
-     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
     private $id;
 
-    /**
-     * @ORM\Column(type="string", length=255)
-     */
-    protected $name;
-
-    /**
-     * @ORM\Column(type="string", length=255)
-     */
+    #[ORM\Column(type: 'string', length: 255)]
     protected $description;
+    
+    #[ORM\Column(type: 'string', length: 255)]
+    protected $fieldsYouNeedToTranslate;
 
     public function getId(): ?int
     {
         return $this->id;
-    }
-
-    public function getName(): string
-    {
-        return $this->name;
-    }
-
-    public function setName(string $name): void
-    {
-        $this->name = $name;
     }
 
     public function getDescription(): string
@@ -71,14 +56,17 @@ class CategoryTranslation implements TranslationInterface
     {
         $this->description = $description;
     }
+    
+    ...
 }
 ```
 
-The corresponding Category entity needs to `use Translatable;`
-and should only contain fields that you do not need to translate.
+This entity must implement Translatable interface and use Translatable trait. 
+this entity should only contain fields that you don't need to translate.
 
 ```php
 <?php
+
 
 declare(strict_types=1);    
 
@@ -88,23 +76,17 @@ use Doctrine\ORM\Mapping as ORM;
 use Knp\DoctrineBehaviors\Contract\Entity\TranslatableInterface;
 use Knp\DoctrineBehaviors\Model\Translatable\TranslatableTrait;
 
-/**
- * @ORM\Entity
- */
+#[ORM\Entity]
 class Category implements TranslatableInterface
 {
     use TranslatableTrait;
     
-    /**
-     * @ORM\Id
-     * @ORM\Column(type="integer")
-     * @ORM\GeneratedValue(strategy="AUTO")
-     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
     private $id;
 
-    /**
-     * @ORM\Column(type="string", length=255)
-     */
+    #[ORM\Column(type: 'string', length: 255)]
     protected $someFieldYouDoNotNeedToTranslate;
     
     public function getId(): ?int


### PR DESCRIPTION
- Convert translatable.md examples to use attributes
- Add example of how to use Translatable with API Platform in translatable-api-platform.md