### PR TITLE
Add doctrine join table inheritance compatibility

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -105,6 +105,10 @@ parameters:
                 - tests/Fixtures/Entity/TranslatableCustomizedEntity.php
                 - tests/Fixtures/Entity/Translation/TranslatableCustomizedEntityTranslation.php
 
+        -
+            message: '#There should be no empty class#'
+            path: tests/Fixtures/Entity/Translatable/ExtendedTranslatableEntityWithJoinTableInheritanceTranslation.php
+
         # false positive, already checked for type
         -
             message: '#Cannot call method getName\(\) on ReflectionClass\|null#'

--- a/src/EventSubscriber/TranslatableEventSubscriber.php
+++ b/src/EventSubscriber/TranslatableEventSubscriber.php
@@ -28,9 +28,10 @@ final class TranslatableEventSubscriber implements EventSubscriberInterface
 
     public function __construct(
         private LocaleProviderInterface $localeProvider,
-        string $translatableFetchMode,
-        string $translationFetchMode
-    ) {
+        string                          $translatableFetchMode,
+        string                          $translationFetchMode
+    )
+    {
         $this->translatableFetchMode = $this->convertFetchString($translatableFetchMode);
         $this->translationFetchMode = $this->convertFetchString($translationFetchMode);
     }
@@ -41,7 +42,7 @@ final class TranslatableEventSubscriber implements EventSubscriberInterface
     public function loadClassMetadata(LoadClassMetadataEventArgs $loadClassMetadataEventArgs): void
     {
         $classMetadata = $loadClassMetadataEventArgs->getClassMetadata();
-        if (! $classMetadata->reflClass instanceof ReflectionClass) {
+        if (!$classMetadata->reflClass instanceof ReflectionClass) {
             // Class has not yet been fully built, ignore this event
             return;
         }
@@ -118,7 +119,7 @@ final class TranslatableEventSubscriber implements EventSubscriberInterface
 
     private function mapTranslation(ClassMetadataInfo $classMetadataInfo, ObjectManager $objectManager): void
     {
-        if (! $classMetadataInfo->hasAssociation('translatable')) {
+        if (!$classMetadataInfo->hasAssociation('translatable')) {
             $targetEntity = $classMetadataInfo->getReflectionClass()
                 ->getMethod('getTranslatableEntityClass')
                 ->invoke(null);
@@ -143,13 +144,14 @@ final class TranslatableEventSubscriber implements EventSubscriberInterface
         }
 
         $name = $classMetadataInfo->getTableName() . '_unique_translation';
-        if (! $this->hasUniqueTranslationConstraint($classMetadataInfo, $name)) {
+        if (!$this->hasUniqueTranslationConstraint($classMetadataInfo, $name) &&
+            $classMetadataInfo->getName() === $classMetadataInfo->rootEntityName) {
             $classMetadataInfo->table['uniqueConstraints'][$name] = [
                 'columns' => ['translatable_id', self::LOCALE],
             ];
         }
 
-        if (! $classMetadataInfo->hasField(self::LOCALE) && ! $classMetadataInfo->hasAssociation(self::LOCALE)) {
+        if (!$classMetadataInfo->hasField(self::LOCALE) && !$classMetadataInfo->hasAssociation(self::LOCALE)) {
             $classMetadataInfo->mapField([
                 'fieldName' => self::LOCALE,
                 'type' => 'string',
@@ -161,7 +163,7 @@ final class TranslatableEventSubscriber implements EventSubscriberInterface
     private function setLocales(LifecycleEventArgs $lifecycleEventArgs): void
     {
         $entity = $lifecycleEventArgs->getEntity();
-        if (! $entity instanceof TranslatableInterface) {
+        if (!$entity instanceof TranslatableInterface) {
             return;
         }
 

--- a/src/EventSubscriber/TranslatableEventSubscriber.php
+++ b/src/EventSubscriber/TranslatableEventSubscriber.php
@@ -30,8 +30,7 @@ final class TranslatableEventSubscriber implements EventSubscriberInterface
         private LocaleProviderInterface $localeProvider,
         string                          $translatableFetchMode,
         string                          $translationFetchMode
-    )
-    {
+    ) {
         $this->translatableFetchMode = $this->convertFetchString($translatableFetchMode);
         $this->translationFetchMode = $this->convertFetchString($translationFetchMode);
     }
@@ -42,7 +41,7 @@ final class TranslatableEventSubscriber implements EventSubscriberInterface
     public function loadClassMetadata(LoadClassMetadataEventArgs $loadClassMetadataEventArgs): void
     {
         $classMetadata = $loadClassMetadataEventArgs->getClassMetadata();
-        if (!$classMetadata->reflClass instanceof ReflectionClass) {
+        if (! $classMetadata->reflClass instanceof ReflectionClass) {
             // Class has not yet been fully built, ignore this event
             return;
         }
@@ -119,7 +118,7 @@ final class TranslatableEventSubscriber implements EventSubscriberInterface
 
     private function mapTranslation(ClassMetadataInfo $classMetadataInfo, ObjectManager $objectManager): void
     {
-        if (!$classMetadataInfo->hasAssociation('translatable')) {
+        if (! $classMetadataInfo->hasAssociation('translatable')) {
             $targetEntity = $classMetadataInfo->getReflectionClass()
                 ->getMethod('getTranslatableEntityClass')
                 ->invoke(null);
@@ -144,14 +143,14 @@ final class TranslatableEventSubscriber implements EventSubscriberInterface
         }
 
         $name = $classMetadataInfo->getTableName() . '_unique_translation';
-        if (!$this->hasUniqueTranslationConstraint($classMetadataInfo, $name) &&
+        if (! $this->hasUniqueTranslationConstraint($classMetadataInfo, $name) &&
             $classMetadataInfo->getName() === $classMetadataInfo->rootEntityName) {
             $classMetadataInfo->table['uniqueConstraints'][$name] = [
                 'columns' => ['translatable_id', self::LOCALE],
             ];
         }
 
-        if (!$classMetadataInfo->hasField(self::LOCALE) && !$classMetadataInfo->hasAssociation(self::LOCALE)) {
+        if (! $classMetadataInfo->hasField(self::LOCALE) && ! $classMetadataInfo->hasAssociation(self::LOCALE)) {
             $classMetadataInfo->mapField([
                 'fieldName' => self::LOCALE,
                 'type' => 'string',
@@ -163,7 +162,7 @@ final class TranslatableEventSubscriber implements EventSubscriberInterface
     private function setLocales(LifecycleEventArgs $lifecycleEventArgs): void
     {
         $entity = $lifecycleEventArgs->getEntity();
-        if (!$entity instanceof TranslatableInterface) {
+        if (! $entity instanceof TranslatableInterface) {
             return;
         }
 

--- a/tests/Fixtures/Entity/Translatable/ExtendedTranslatableEntityWithJoinTableInheritance.php
+++ b/tests/Fixtures/Entity/Translatable/ExtendedTranslatableEntityWithJoinTableInheritance.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Knp\DoctrineBehaviors\Tests\Fixtures\Entity\Translatable;
 
 use Doctrine\ORM\Mapping\Column;
@@ -13,7 +15,6 @@ class ExtendedTranslatableEntityWithJoinTableInheritance extends TranslatableEnt
     private ?string $untranslatedField = null;
 
     /**
-     * @return mixed
      * @throws ShouldNotHappenException
      */
     public function getUntranslatedField(): string
@@ -24,9 +25,6 @@ class ExtendedTranslatableEntityWithJoinTableInheritance extends TranslatableEnt
         return $this->untranslatedField;
     }
 
-    /**
-     * @param mixed $untranslatedField
-     */
     public function setUntranslatedField(String $untranslatedField): void
     {
         $this->untranslatedField = $untranslatedField;

--- a/tests/Fixtures/Entity/Translatable/ExtendedTranslatableEntityWithJoinTableInheritance.php
+++ b/tests/Fixtures/Entity/Translatable/ExtendedTranslatableEntityWithJoinTableInheritance.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Knp\DoctrineBehaviors\Tests\Fixtures\Entity\Translatable;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Knp\DoctrineBehaviors\Exception\ShouldNotHappenException;
+
+#[Entity]
+class ExtendedTranslatableEntityWithJoinTableInheritance extends TranslatableEntityWithJoinTableInheritance
+{
+    #[Column(type: 'string')]
+    private ?string $untranslatedField = null;
+
+    /**
+     * @return mixed
+     * @throws ShouldNotHappenException
+     */
+    public function getUntranslatedField(): string
+    {
+        if ($this->untranslatedField === null) {
+            throw new ShouldNotHappenException();
+        }
+        return $this->untranslatedField;
+    }
+
+    /**
+     * @param mixed $untranslatedField
+     */
+    public function setUntranslatedField(String $untranslatedField): void
+    {
+        $this->untranslatedField = $untranslatedField;
+    }
+}

--- a/tests/Fixtures/Entity/Translatable/ExtendedTranslatableEntityWithJoinTableInheritance.php
+++ b/tests/Fixtures/Entity/Translatable/ExtendedTranslatableEntityWithJoinTableInheritance.php
@@ -22,6 +22,7 @@ class ExtendedTranslatableEntityWithJoinTableInheritance extends TranslatableEnt
         if ($this->untranslatedField === null) {
             throw new ShouldNotHappenException();
         }
+
         return $this->untranslatedField;
     }
 

--- a/tests/Fixtures/Entity/Translatable/ExtendedTranslatableEntityWithJoinTableInheritanceTranslation.php
+++ b/tests/Fixtures/Entity/Translatable/ExtendedTranslatableEntityWithJoinTableInheritanceTranslation.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Knp\DoctrineBehaviors\Tests\Fixtures\Entity\Translatable;
+
+use Doctrine\ORM\Mapping\Entity;
+
+#[Entity]
+class ExtendedTranslatableEntityWithJoinTableInheritanceTranslation extends TranslatableEntityWithJoinTableInheritanceTranslation
+{
+
+}

--- a/tests/Fixtures/Entity/Translatable/ExtendedTranslatableEntityWithJoinTableInheritanceTranslation.php
+++ b/tests/Fixtures/Entity/Translatable/ExtendedTranslatableEntityWithJoinTableInheritanceTranslation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Knp\DoctrineBehaviors\Tests\Fixtures\Entity\Translatable;
 
 use Doctrine\ORM\Mapping\Entity;
@@ -7,5 +9,4 @@ use Doctrine\ORM\Mapping\Entity;
 #[Entity]
 class ExtendedTranslatableEntityWithJoinTableInheritanceTranslation extends TranslatableEntityWithJoinTableInheritanceTranslation
 {
-
 }

--- a/tests/Fixtures/Entity/Translatable/TranslatableEntityWithJoinTableInheritance.php
+++ b/tests/Fixtures/Entity/Translatable/TranslatableEntityWithJoinTableInheritance.php
@@ -14,7 +14,7 @@ use Knp\DoctrineBehaviors\Contract\Entity\TranslatableInterface;
 use Knp\DoctrineBehaviors\Model\Translatable\TranslatableTrait;
 
 #[Entity]
-#[InheritanceType('JOINED')]
+#[InheritanceType(value: 'JOINED')]
 #[DiscriminatorColumn(name:'handle', type:'string')]
 class TranslatableEntityWithJoinTableInheritance implements TranslatableInterface
 {

--- a/tests/Fixtures/Entity/Translatable/TranslatableEntityWithJoinTableInheritance.php
+++ b/tests/Fixtures/Entity/Translatable/TranslatableEntityWithJoinTableInheritance.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Knp\DoctrineBehaviors\Tests\Fixtures\Entity\Translatable;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\DiscriminatorColumn;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\InheritanceType;
+use Knp\DoctrineBehaviors\Contract\Entity\TranslatableInterface;
+use Knp\DoctrineBehaviors\Model\Translatable\TranslatableTrait;
+
+#[Entity]
+#[InheritanceType("JOINED")]
+#[DiscriminatorColumn(name:"handle", type:"string")]
+class TranslatableEntityWithJoinTableInheritance implements TranslatableInterface
+{
+    use TranslatableTrait;
+
+    /**
+     * @return mixed
+     */
+    public function __call(string $method, array $arguments)
+    {
+        return $this->proxyCurrentLocaleTranslation($method, $arguments);
+    }
+
+    #[Id]
+    #[Column(type: 'integer')]
+    #[GeneratedValue(strategy: 'AUTO')]
+    private int $id;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+}

--- a/tests/Fixtures/Entity/Translatable/TranslatableEntityWithJoinTableInheritance.php
+++ b/tests/Fixtures/Entity/Translatable/TranslatableEntityWithJoinTableInheritance.php
@@ -14,11 +14,16 @@ use Knp\DoctrineBehaviors\Contract\Entity\TranslatableInterface;
 use Knp\DoctrineBehaviors\Model\Translatable\TranslatableTrait;
 
 #[Entity]
-#[InheritanceType("JOINED")]
-#[DiscriminatorColumn(name:"handle", type:"string")]
+#[InheritanceType('JOINED')]
+#[DiscriminatorColumn(name:'handle', type:'string')]
 class TranslatableEntityWithJoinTableInheritance implements TranslatableInterface
 {
     use TranslatableTrait;
+
+    #[Id]
+    #[Column(type: 'integer')]
+    #[GeneratedValue(strategy: 'AUTO')]
+    private int $id;
 
     /**
      * @return mixed
@@ -28,14 +33,8 @@ class TranslatableEntityWithJoinTableInheritance implements TranslatableInterfac
         return $this->proxyCurrentLocaleTranslation($method, $arguments);
     }
 
-    #[Id]
-    #[Column(type: 'integer')]
-    #[GeneratedValue(strategy: 'AUTO')]
-    private int $id;
-
     public function getId(): int
     {
         return $this->id;
     }
-
 }

--- a/tests/Fixtures/Entity/Translatable/TranslatableEntityWithJoinTableInheritanceTranslation.php
+++ b/tests/Fixtures/Entity/Translatable/TranslatableEntityWithJoinTableInheritanceTranslation.php
@@ -15,8 +15,8 @@ use Knp\DoctrineBehaviors\Exception\ShouldNotHappenException;
 use Knp\DoctrineBehaviors\Model\Translatable\TranslationTrait;
 
 #[Entity]
-#[InheritanceType("JOINED")]
-#[DiscriminatorColumn(name:"handle", type:"string")]
+#[InheritanceType('JOINED')]
+#[DiscriminatorColumn(name:'handle', type:'string')]
 class TranslatableEntityWithJoinTableInheritanceTranslation implements TranslationInterface
 {
     use TranslationTrait;

--- a/tests/Fixtures/Entity/Translatable/TranslatableEntityWithJoinTableInheritanceTranslation.php
+++ b/tests/Fixtures/Entity/Translatable/TranslatableEntityWithJoinTableInheritanceTranslation.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Knp\DoctrineBehaviors\Tests\Fixtures\Entity\Translatable;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\DiscriminatorColumn;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\InheritanceType;
+use Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface;
+use Knp\DoctrineBehaviors\Exception\ShouldNotHappenException;
+use Knp\DoctrineBehaviors\Model\Translatable\TranslationTrait;
+
+#[Entity]
+#[InheritanceType("JOINED")]
+#[DiscriminatorColumn(name:"handle", type:"string")]
+class TranslatableEntityWithJoinTableInheritanceTranslation implements TranslationInterface
+{
+    use TranslationTrait;
+
+    #[Id]
+    #[Column(type: 'integer')]
+    #[GeneratedValue(strategy: 'AUTO')]
+    private int $id;
+
+    #[Column(type: 'string')]
+    private ?string $title = null;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @throws ShouldNotHappenException
+     */
+    public function getTitle(): string
+    {
+        if ($this->title === null) {
+            throw new ShouldNotHappenException();
+        }
+
+        return $this->title;
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+}

--- a/tests/Fixtures/Entity/Translatable/TranslatableEntityWithJoinTableInheritanceTranslation.php
+++ b/tests/Fixtures/Entity/Translatable/TranslatableEntityWithJoinTableInheritanceTranslation.php
@@ -15,7 +15,7 @@ use Knp\DoctrineBehaviors\Exception\ShouldNotHappenException;
 use Knp\DoctrineBehaviors\Model\Translatable\TranslationTrait;
 
 #[Entity]
-#[InheritanceType('JOINED')]
+#[InheritanceType(value: 'JOINED')]
 #[DiscriminatorColumn(name:'handle', type:'string')]
 class TranslatableEntityWithJoinTableInheritanceTranslation implements TranslationInterface
 {

--- a/tests/ORM/Translatable/TranslatableJoinTableInheritanceTest.php
+++ b/tests/ORM/Translatable/TranslatableJoinTableInheritanceTest.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace Knp\DoctrineBehaviors\Tests\ORM\Translatable;
 
-use Doctrine\DBAL\Schema\SchemaException;
 use Doctrine\Persistence\ObjectRepository;
 use Knp\DoctrineBehaviors\Tests\AbstractBehaviorTestCase;
 use Knp\DoctrineBehaviors\Tests\Fixtures\Entity\Translatable\ExtendedTranslatableEntity;
 use Knp\DoctrineBehaviors\Tests\Fixtures\Entity\Translatable\ExtendedTranslatableEntityWithJoinTableInheritance;
-use Knp\DoctrineBehaviors\Tests\Fixtures\Entity\Translatable\TranslatableEntityWithJoinTableInheritance;
 
 final class TranslatableJoinTableInheritanceTest extends AbstractBehaviorTestCase
 {
@@ -22,16 +20,21 @@ final class TranslatableJoinTableInheritanceTest extends AbstractBehaviorTestCas
     {
         parent::setUp();
 
-        $this->objectRepository = $this->entityManager->getRepository(ExtendedTranslatableEntityWithJoinTableInheritance::class);
+        $this->objectRepository = $this->entityManager->getRepository(
+            ExtendedTranslatableEntityWithJoinTableInheritance::class
+        );
     }
 
     public function testShouldPersistTranslationsWithJoinTableInheritance(): void
     {
         $entity = new ExtendedTranslatableEntityWithJoinTableInheritance();
         $entity->setUntranslatedField('untranslated');
-        $entity->translate('fr')->setTitle('fabuleux');
-        $entity->translate('en')->setTitle('awesome');
-        $entity->translate('ru')->setTitle('удивительный');
+        $entity->translate('fr')
+            ->setTitle('fabuleux');
+        $entity->translate('en')
+            ->setTitle('awesome');
+        $entity->translate('ru')
+            ->setTitle('удивительный');
 
         $entity->mergeNewTranslations();
 
@@ -41,13 +44,11 @@ final class TranslatableJoinTableInheritanceTest extends AbstractBehaviorTestCas
         $id = $entity->getId();
         $this->entityManager->clear();
 
-        /** @var  ExtendedTranslatableEntityWithJoinTableInheritance $entity */
+        /** @var ExtendedTranslatableEntityWithJoinTableInheritance $entity */
         $entity = $this->objectRepository->find($id);
         $this->assertSame('untranslated', $entity->getUntranslatedField());
         $this->assertSame('fabuleux', $entity->translate('fr')->getTitle());
         $this->assertSame('awesome', $entity->translate('en')->getTitle());
         $this->assertSame('удивительный', $entity->translate('ru')->getTitle());
     }
-
-
 }

--- a/tests/ORM/Translatable/TranslatableJoinTableInheritanceTest.php
+++ b/tests/ORM/Translatable/TranslatableJoinTableInheritanceTest.php
@@ -12,7 +12,7 @@ use Knp\DoctrineBehaviors\Tests\Fixtures\Entity\Translatable\ExtendedTranslatabl
 final class TranslatableJoinTableInheritanceTest extends AbstractBehaviorTestCase
 {
     /**
-     * @var ObjectRepository<ExtendedTranslatableEntity>
+     * @var ObjectRepository<ExtendedTranslatableEntityWithJoinTableInheritance>
      */
     private ObjectRepository $objectRepository;
 

--- a/tests/ORM/Translatable/TranslatableJoinTableInheritanceTest.php
+++ b/tests/ORM/Translatable/TranslatableJoinTableInheritanceTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Knp\DoctrineBehaviors\Tests\ORM\Translatable;
+
+use Doctrine\DBAL\Schema\SchemaException;
+use Doctrine\Persistence\ObjectRepository;
+use Knp\DoctrineBehaviors\Tests\AbstractBehaviorTestCase;
+use Knp\DoctrineBehaviors\Tests\Fixtures\Entity\Translatable\ExtendedTranslatableEntity;
+use Knp\DoctrineBehaviors\Tests\Fixtures\Entity\Translatable\ExtendedTranslatableEntityWithJoinTableInheritance;
+use Knp\DoctrineBehaviors\Tests\Fixtures\Entity\Translatable\TranslatableEntityWithJoinTableInheritance;
+
+final class TranslatableJoinTableInheritanceTest extends AbstractBehaviorTestCase
+{
+    /**
+     * @var ObjectRepository<ExtendedTranslatableEntity>
+     */
+    private ObjectRepository $objectRepository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->objectRepository = $this->entityManager->getRepository(ExtendedTranslatableEntityWithJoinTableInheritance::class);
+    }
+
+    public function testShouldPersistTranslationsWithJoinTableInheritance(): void
+    {
+        $entity = new ExtendedTranslatableEntityWithJoinTableInheritance();
+        $entity->setUntranslatedField('untranslated');
+        $entity->translate('fr')->setTitle('fabuleux');
+        $entity->translate('en')->setTitle('awesome');
+        $entity->translate('ru')->setTitle('удивительный');
+
+        $entity->mergeNewTranslations();
+
+        $this->entityManager->persist($entity);
+        $this->entityManager->flush();
+
+        $id = $entity->getId();
+        $this->entityManager->clear();
+
+        /** @var  ExtendedTranslatableEntityWithJoinTableInheritance $entity */
+        $entity = $this->objectRepository->find($id);
+        $this->assertSame('untranslated', $entity->getUntranslatedField());
+        $this->assertSame('fabuleux', $entity->translate('fr')->getTitle());
+        $this->assertSame('awesome', $entity->translate('en')->getTitle());
+        $this->assertSame('удивительный', $entity->translate('ru')->getTitle());
+    }
+
+
+}

--- a/tests/ORM/Translatable/TranslatableJoinTableInheritanceTest.php
+++ b/tests/ORM/Translatable/TranslatableJoinTableInheritanceTest.php
@@ -6,7 +6,6 @@ namespace Knp\DoctrineBehaviors\Tests\ORM\Translatable;
 
 use Doctrine\Persistence\ObjectRepository;
 use Knp\DoctrineBehaviors\Tests\AbstractBehaviorTestCase;
-use Knp\DoctrineBehaviors\Tests\Fixtures\Entity\Translatable\ExtendedTranslatableEntity;
 use Knp\DoctrineBehaviors\Tests\Fixtures\Entity\Translatable\ExtendedTranslatableEntityWithJoinTableInheritance;
 
 final class TranslatableJoinTableInheritanceTest extends AbstractBehaviorTestCase


### PR DESCRIPTION
This PR adds a failing test and a fix for #307 #317 and #336.

**As a short summary:** 

Whenever you use doctrine joined inheritance you get a `Doctrine\DBAL\Schema\SchemaException: There is no column with name 'translatable_id' on table`. 

This is because a unique constraint is going to be set for the translation subclass but this class don't have this column. This comment describes it well and also suggest the fix: https://github.com/KnpLabs/DoctrineBehaviors/issues/307#issuecomment-231264716