### PR TITLE
Fix phpstan behaviors to allow an interface inherited from TranslatableInterface

### DIFF
--- a/tests/Fixtures/Contract/Translatable/ExtendedTranslatableInterface.php
+++ b/tests/Fixtures/Contract/Translatable/ExtendedTranslatableInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Knp\DoctrineBehaviors\Tests\Fixtures\Contract\Translatable;
+
+use Knp\DoctrineBehaviors\Contract\Entity\TranslatableInterface;
+
+interface ExtendedTranslatableInterface extends TranslatableInterface
+{
+}

--- a/tests/Fixtures/Contract/Translatable/TranslatableEntityWithCustomInterface.php
+++ b/tests/Fixtures/Contract/Translatable/TranslatableEntityWithCustomInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Knp\DoctrineBehaviors\Tests\Fixtures\Contract\Translatable;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Knp\DoctrineBehaviors\Model\Translatable\TranslatableTrait;
+
+#[Entity]
+class TranslatableEntityWithCustomInterface implements ExtendedTranslatableInterface
+{
+    use TranslatableTrait;
+
+    #[Id]
+    #[Column(type: 'integer')]
+    #[GeneratedValue(strategy: 'AUTO')]
+    private int $id;
+
+    /**
+     * @return mixed
+     */
+    public function __call(string $method, array $arguments)
+    {
+        return $this->proxyCurrentLocaleTranslation($method, $arguments);
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+}

--- a/tests/Fixtures/Contract/Translatable/TranslatableEntityWithCustomInterfaceTranslation.php
+++ b/tests/Fixtures/Contract/Translatable/TranslatableEntityWithCustomInterfaceTranslation.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Knp\DoctrineBehaviors\Tests\Fixtures\Contract\Translatable;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Knp\DoctrineBehaviors\Tests\Fixtures\Entity\Translatable\AbstractTranslatableEntityTranslation;
+
+#[Entity]
+class TranslatableEntityWithCustomInterfaceTranslation extends AbstractTranslatableEntityTranslation
+{
+    #[Id]
+    #[Column(type: 'integer')]
+    #[GeneratedValue(strategy: 'AUTO')]
+    private int $id;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+}

--- a/tests/ORM/Translatable/TranslatableTest.php
+++ b/tests/ORM/Translatable/TranslatableTest.php
@@ -9,6 +9,7 @@ use Doctrine\Persistence\ObjectRepository;
 use Knp\DoctrineBehaviors\Contract\Entity\TranslatableInterface;
 use Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface;
 use Knp\DoctrineBehaviors\Tests\AbstractBehaviorTestCase;
+use Knp\DoctrineBehaviors\Tests\Fixtures\Contract\Translatable\TranslatableEntityWithCustomInterface;
 use Knp\DoctrineBehaviors\Tests\Fixtures\Entity\TranslatableCustomIdentifierEntity;
 use Knp\DoctrineBehaviors\Tests\Fixtures\Entity\TranslatableCustomizedEntity;
 use Knp\DoctrineBehaviors\Tests\Fixtures\Entity\TranslatableEntity;
@@ -381,6 +382,16 @@ final class TranslatableTest extends AbstractBehaviorTestCase
         $this->assertFalse($translatableEntity->translate('en')->isEmpty());
         $this->assertSame('0', $translatableEntity->translate('fr')->getTitle());
         $this->assertSame('0', $translatableEntity->translate('en')->getTitle());
+    }
+
+    public function testCustomInterface(): void
+    {
+        $translatableEntityWithCustom = new TranslatableEntityWithCustomInterface();
+        $translatableEntityWithCustom->translate('en')
+            ->setTitle('awesome');
+        $translatableEntityWithCustom->mergeNewTranslations();
+
+        $this->assertSame('awesome', $translatableEntityWithCustom->translate('en')->getTitle());
     }
 
     /**

--- a/utils/phpstan-behaviors/src/Type/StaticTranslationTypeHelper.php
+++ b/utils/phpstan-behaviors/src/Type/StaticTranslationTypeHelper.php
@@ -32,7 +32,9 @@ final class StaticTranslationTypeHelper
         }
 
         if ($reflectionClass->isInterface()) {
-            if ($reflectionClass->getName() === TranslatableInterface::class) {
+            if ($reflectionClass->getName() === TranslatableInterface::class || $reflectionClass->implementsInterface(
+                TranslatableInterface::class
+            )) {
                 return TranslationInterface::class;
             }
 
@@ -59,7 +61,9 @@ final class StaticTranslationTypeHelper
             ->getNativeReflection();
 
         if ($nativeReflection->isInterface()) {
-            if ($nativeReflection->getName() === TranslationInterface::class) {
+            if ($nativeReflection->getName() === TranslationInterface::class || $nativeReflection->implementsInterface(
+                TranslationInterface::class
+            )) {
                 return TranslatableInterface::class;
             }
 


### PR DESCRIPTION
If I use my own TranslatableInterface instead of the one provided by the bundle, phpstan throw an error. 

Here an example 

```php
use Acme\Contract\TranslatableInterface;

class Product implements TranslatableInterface
{
}
```

```php
use Knp\DoctrineBehaviors\Contract\Entity\TranslatableInterface as KnpTranslatableInterface;

interface TranslatableInterface extends KnpTranslatableInterface
{
}
```

Thx !

PS: Sorry I've closed the previous PR (#695) after a mistake :sweat: 