### PR TITLE
Remove indirect deprecation notices

### DIFF
--- a/src/Provider/UserProvider.php
+++ b/src/Provider/UserProvider.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Knp\DoctrineBehaviors\Provider;
 
 use Knp\DoctrineBehaviors\Contract\Provider\UserProviderInterface;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Bundle\SecurityBundle\Security;
 
 final class UserProvider implements UserProviderInterface
 {


### PR DESCRIPTION
As of Symfony 6.2, The "Symfony\Component\Security\Core\Security" service alias is deprecated, use "Symfony\Bundle\SecurityBundle\Security" instead