### PR TITLE
doc(translatable): Add a tips about Doctrine Migration

### DIFF
--- a/docs/translatable-migration.md
+++ b/docs/translatable-migration.md
@@ -1,0 +1,43 @@
+# Translatable - Keep existing content with Doctrine Migration
+
+When adding Translatable to an existing project, Doctrine Migration is going to blindly remove your table columns as you moved them to Translatable dedicated entities.
+
+Here is how you can edit your Doctrine Migration to keep your contributed database content.
+
+Let's see an example with a **Product** entity owning a **description** property. You moved this property to the **ProductTranslation** entity. Your initial Doctrine migration will look like this:
+
+```php
+final class Version20221111111111 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE product_translation (id INT AUTO_INCREMENT NOT NULL, translatable_id INT DEFAULT NULL, description LONGTEXT DEFAULT NULL, locale VARCHAR(5) NOT NULL, INDEX IDX_BE61F5EA2C2AC5D3 (translatable_id), UNIQUE INDEX product_translation_unique_translation (translatable_id, locale), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE product_translation ADD CONSTRAINT FK_BE61F5EA2C2AC5D3 FOREIGN KEY (translatable_id) REFERENCES product (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE product DROP description');
+    }
+    
+    // ...
+}
+```
+
+The last SQL is problematic: `DROP description` will permanently delete all the contributed descriptions.
+
+All you need to do is add a new SQL statement manually, between the **CREATE TABLE** and the **DROP description**, to move your content using the **INSERT ... SELECT** notation:
+
+```sql
+INSERT INTO product_translation (translatable_id, description, locale) SELECT id, description, 'en' FROM product;
+```
+
+The modification is as follows:
+
+```diff
+public function up(Schema $schema): void
+{
+    $this->addSql('CREATE TABLE product_translation (id INT AUTO_INCREMENT NOT NULL, translatable_id INT DEFAULT NULL, description LONGTEXT DEFAULT NULL, locale VARCHAR(5) NOT NULL, INDEX IDX_BE61F5EA2C2AC5D3 (translatable_id), UNIQUE INDEX product_translation_unique_translation (translatable_id, locale), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+    $this->addSql('ALTER TABLE product_translation ADD CONSTRAINT FK_BE61F5EA2C2AC5D3 FOREIGN KEY (translatable_id) REFERENCES product (id) ON DELETE CASCADE');
++    $this->addSql('INSERT INTO product_translation (translatable_id, description, locale) SELECT id, description, 'en' FROM product;');
+    $this->addSql('ALTER TABLE product DROP description');
+}
+```
+
+Make sure to add all your fields and edit the locale if you don't come from "en" like in the example.

--- a/docs/translatable.md
+++ b/docs/translatable.md
@@ -8,7 +8,10 @@ same folder, e.g.:
 
 The default naming convention (or its customization via trait methods) avoids you to manually handle entity associations. It is handled automatically by the `TranslatableEventSubscriber`.
 
-[How to use translatable with api platform?](/docs/translatable-api-platform.md)
+Related documentations:
+
+- [How to use translatable with api platform?](/docs/translatable-api-platform.md)
+- [How to tweak your Doctrine Migration to keep existing content?](/docs/translatable-migration.md)
 
 ## Entity
 


### PR DESCRIPTION
I'd like to add a small tip about Doctrine Migration and existing projects getting Translatable setup after some content have been contributed.

It's just an easy thing to miss locally because fixtures are applied later, but that could be a shame once deployed to production :smiley_cat: 

