### PR TITLE
use SymfonyBundle for security instead of core

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
         "symfony/cache": "^5.4|^6.0",
         "symfony/dependency-injection": "^5.4|^6.0",
         "symfony/http-kernel": "^5.4|^6.0",
-        "symfony/security-core": "^5.4|^6.0",
         "symfony/framework-bundle": "^5.4|^6.0",
         "symfony/string": "^5.4|^6.0",
+        "symfony/security-bundle": "^5.4|^6.0",
         "symfony/translation-contracts": "^2.4|^3.0",
         "nette/utils": "^3.2",
         "ramsey/uuid": "^4.2"

--- a/src/Bundle/DependencyInjection/DoctrineBehaviorsExtension.php
+++ b/src/Bundle/DependencyInjection/DoctrineBehaviorsExtension.php
@@ -11,8 +11,9 @@ use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 
 final class DoctrineBehaviorsExtension extends Extension
 {
+
     /**
-     * @param string[] $configs
+     * @inheritDoc
      */
     public function load(array $configs, ContainerBuilder $containerBuilder): void
     {

--- a/src/Model/Tree/TreeNodeMethodsTrait.php
+++ b/src/Model/Tree/TreeNodeMethodsTrait.php
@@ -271,7 +271,7 @@ trait TreeNodeMethodsTrait
     /**
      * @return mixed
      */
-    public function offsetGet(mixed $offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->getChildNodes()[$offset];
     }

--- a/src/Provider/UserProvider.php
+++ b/src/Provider/UserProvider.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Knp\DoctrineBehaviors\Provider;
 
 use Knp\DoctrineBehaviors\Contract\Provider\UserProviderInterface;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Bundle\SecurityBundle\Security;
 
 final class UserProvider implements UserProviderInterface
 {


### PR DESCRIPTION
This gets rid of the deprecation error.  phpunit tests pass.