### PR TITLE
Update TreeNodePropertiesTrait.php

### DIFF
--- a/src/Model/Tree/TreeNodePropertiesTrait.php
+++ b/src/Model/Tree/TreeNodePropertiesTrait.php
@@ -23,4 +23,9 @@ trait TreeNodePropertiesTrait
      * @var TreeNodeInterface|null
      */
     private $parentNode;
+
+    /**
+     * @var string
+     */
+    private $parentNodePath;
 }


### PR DESCRIPTION
Add missing ``parentNodePath`` property in TreeNodePropertiesTrait as it's used in TreeNodeMethodsTrait to fix the following deprecation (raised starting from PHP 8.2):

Creation of dynamic property PTC\NoventoBundle\Entity\Menu::$parentNodePath is deprecated