### PR TITLE
Fix SF62 / SF63 deprecations (doctrine subscriber deprecated)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "doctrine/persistence": "^2.5|^3.0",
         "doctrine/dbal": "^3.3",
         "doctrine/orm": "^2.12",
-        "doctrine/doctrine-bundle": "^2.6",
+        "doctrine/doctrine-bundle": "^2.7.2",
         "symfony/cache": "^5.4|^6.0",
         "symfony/dependency-injection": "^5.4|^6.0",
         "symfony/http-kernel": "^5.4|^6.0",

--- a/src/EventSubscriber/BlameableEventSubscriber.php
+++ b/src/EventSubscriber/BlameableEventSubscriber.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Knp\DoctrineBehaviors\EventSubscriber;
 
-use Doctrine\Bundle\DoctrineBundle\EventSubscriber\EventSubscriberInterface;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
@@ -14,7 +14,11 @@ use Doctrine\ORM\UnitOfWork;
 use Knp\DoctrineBehaviors\Contract\Entity\BlameableInterface;
 use Knp\DoctrineBehaviors\Contract\Provider\UserProviderInterface;
 
-final class BlameableEventSubscriber implements EventSubscriberInterface
+#[AsDoctrineListener(event: Events::loadClassMetadata)]
+#[AsDoctrineListener(event: Events::prePersist)]
+#[AsDoctrineListener(event: Events::preUpdate)]
+#[AsDoctrineListener(event: Events::preRemove)]
+final class BlameableEventSubscriber
 {
     /**
      * @var string
@@ -129,14 +133,6 @@ final class BlameableEventSubscriber implements EventSubscriberInterface
 
         $this->getUnitOfWork()
             ->propertyChanged($entity, self::DELETED_BY, $oldDeletedBy, $user);
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getSubscribedEvents(): array
-    {
-        return [Events::prePersist, Events::preUpdate, Events::preRemove, Events::loadClassMetadata];
     }
 
     private function mapEntity(ClassMetadataInfo $classMetadataInfo): void

--- a/src/EventSubscriber/LoggableEventSubscriber.php
+++ b/src/EventSubscriber/LoggableEventSubscriber.php
@@ -4,14 +4,17 @@ declare(strict_types=1);
 
 namespace Knp\DoctrineBehaviors\EventSubscriber;
 
-use Doctrine\Bundle\DoctrineBundle\EventSubscriber\EventSubscriberInterface;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
 use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Events;
 use Knp\DoctrineBehaviors\Contract\Entity\LoggableInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 
-final class LoggableEventSubscriber implements EventSubscriberInterface
+#[AsDoctrineListener(event: Events::postPersist)]
+#[AsDoctrineListener(event: Events::postUpdate)]
+#[AsDoctrineListener(event: Events::preRemove)]
+final class LoggableEventSubscriber
 {
     public function __construct(
         private LoggerInterface $logger
@@ -48,14 +51,6 @@ final class LoggableEventSubscriber implements EventSubscriberInterface
         if ($entity instanceof LoggableInterface) {
             $this->logger->log(LogLevel::INFO, $entity->getRemoveLogMessage());
         }
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getSubscribedEvents(): array
-    {
-        return [Events::postPersist, Events::postUpdate, Events::preRemove];
     }
 
     /**

--- a/src/EventSubscriber/SluggableEventSubscriber.php
+++ b/src/EventSubscriber/SluggableEventSubscriber.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Knp\DoctrineBehaviors\EventSubscriber;
 
-use Doctrine\Bundle\DoctrineBundle\EventSubscriber\EventSubscriberInterface;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
@@ -13,7 +13,10 @@ use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Knp\DoctrineBehaviors\Contract\Entity\SluggableInterface;
 use Knp\DoctrineBehaviors\Repository\DefaultSluggableRepository;
 
-final class SluggableEventSubscriber implements EventSubscriberInterface
+#[AsDoctrineListener(event: Events::loadClassMetadata)]
+#[AsDoctrineListener(event: Events::prePersist)]
+#[AsDoctrineListener(event: Events::preUpdate)]
+final class SluggableEventSubscriber
 {
     /**
      * @var string
@@ -48,14 +51,6 @@ final class SluggableEventSubscriber implements EventSubscriberInterface
     public function preUpdate(LifecycleEventArgs $lifecycleEventArgs): void
     {
         $this->processLifecycleEventArgs($lifecycleEventArgs);
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getSubscribedEvents(): array
-    {
-        return [Events::loadClassMetadata, Events::prePersist, Events::preUpdate];
     }
 
     private function shouldSkip(ClassMetadataInfo $classMetadataInfo): bool

--- a/src/EventSubscriber/SoftDeletableEventSubscriber.php
+++ b/src/EventSubscriber/SoftDeletableEventSubscriber.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Knp\DoctrineBehaviors\EventSubscriber;
 
-use Doctrine\Bundle\DoctrineBundle\EventSubscriber\EventSubscriberInterface;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Event\OnFlushEventArgs;
 use Doctrine\ORM\Events;
 use Knp\DoctrineBehaviors\Contract\Entity\SoftDeletableInterface;
 
-final class SoftDeletableEventSubscriber implements EventSubscriberInterface
+#[AsDoctrineListener(event: Events::loadClassMetadata)]
+#[AsDoctrineListener(event: Events::onFlush)]
+final class SoftDeletableEventSubscriber
 {
     /**
      * @var string
@@ -62,11 +64,4 @@ final class SoftDeletableEventSubscriber implements EventSubscriberInterface
         ]);
     }
 
-    /**
-     * @return string[]
-     */
-    public function getSubscribedEvents(): array
-    {
-        return [Events::onFlush, Events::loadClassMetadata];
-    }
 }

--- a/src/EventSubscriber/TimestampableEventSubscriber.php
+++ b/src/EventSubscriber/TimestampableEventSubscriber.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Knp\DoctrineBehaviors\EventSubscriber;
 
-use Doctrine\Bundle\DoctrineBundle\EventSubscriber\EventSubscriberInterface;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Events;
 use Knp\DoctrineBehaviors\Contract\Entity\TimestampableInterface;
 
-final class TimestampableEventSubscriber implements EventSubscriberInterface
+#[AsDoctrineListener(event: Events::loadClassMetadata)]
+final class TimestampableEventSubscriber
 {
     public function __construct(
         private string $timestampableDateFieldType
@@ -46,11 +47,4 @@ final class TimestampableEventSubscriber implements EventSubscriberInterface
         }
     }
 
-    /**
-     * @return string[]
-     */
-    public function getSubscribedEvents(): array
-    {
-        return [Events::loadClassMetadata];
-    }
 }

--- a/src/EventSubscriber/TranslatableEventSubscriber.php
+++ b/src/EventSubscriber/TranslatableEventSubscriber.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Knp\DoctrineBehaviors\EventSubscriber;
 
-use Doctrine\Bundle\DoctrineBundle\EventSubscriber\EventSubscriberInterface;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
 use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Events;
@@ -15,7 +15,10 @@ use Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface;
 use Knp\DoctrineBehaviors\Contract\Provider\LocaleProviderInterface;
 use ReflectionClass;
 
-final class TranslatableEventSubscriber implements EventSubscriberInterface
+#[AsDoctrineListener(event: Events::loadClassMetadata)]
+#[AsDoctrineListener(event: Events::postLoad)]
+#[AsDoctrineListener(event: Events::prePersist)]
+final class TranslatableEventSubscriber
 {
     /**
      * @var string
@@ -69,13 +72,7 @@ final class TranslatableEventSubscriber implements EventSubscriberInterface
         $this->setLocales($lifecycleEventArgs);
     }
 
-    /**
-     * @return string[]
-     */
-    public function getSubscribedEvents(): array
-    {
-        return [Events::loadClassMetadata, Events::postLoad, Events::prePersist];
-    }
+
 
     /**
      * Convert string FETCH mode to required string

--- a/src/EventSubscriber/TreeEventSubscriber.php
+++ b/src/EventSubscriber/TreeEventSubscriber.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Knp\DoctrineBehaviors\EventSubscriber;
 
-use Doctrine\Bundle\DoctrineBundle\EventSubscriber\EventSubscriberInterface;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Events;
 use Knp\DoctrineBehaviors\Contract\Entity\TreeNodeInterface;
 
-final class TreeEventSubscriber implements EventSubscriberInterface
+#[AsDoctrineListener(event: Events::loadClassMetadata)]
+final class TreeEventSubscriber
 {
     public function loadClassMetadata(LoadClassMetadataEventArgs $loadClassMetadataEventArgs): void
     {
@@ -32,13 +33,5 @@ final class TreeEventSubscriber implements EventSubscriberInterface
             'type' => 'string',
             'length' => 255,
         ]);
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getSubscribedEvents(): array
-    {
-        return [Events::loadClassMetadata];
     }
 }

--- a/src/EventSubscriber/UuidableEventSubscriber.php
+++ b/src/EventSubscriber/UuidableEventSubscriber.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Knp\DoctrineBehaviors\EventSubscriber;
 
-use Doctrine\Bundle\DoctrineBundle\EventSubscriber\EventSubscriberInterface;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
 use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Events;
 use Knp\DoctrineBehaviors\Contract\Entity\UuidableInterface;
 
-final class UuidableEventSubscriber implements EventSubscriberInterface
+#[AsDoctrineListener(event: Events::loadClassMetadata)]
+#[AsDoctrineListener(event: Events::prePersist)]
+final class UuidableEventSubscriber
 {
     public function loadClassMetadata(LoadClassMetadataEventArgs $loadClassMetadataEventArgs): void
     {
@@ -43,13 +45,5 @@ final class UuidableEventSubscriber implements EventSubscriberInterface
         }
 
         $entity->generateUuid();
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getSubscribedEvents(): array
-    {
-        return [Events::loadClassMetadata, Events::prePersist];
     }
 }


### PR DESCRIPTION
Fix deprecation raised when using ``doctrine/doctrine-bundle`` starting from v2.10 (see https://github.com/doctrine/DoctrineBundle/commit/656beec9a163b44987a7e79f89f74020d0358b17).

On my test suite (~400 tests) the deprecation is raised 7497x:
```
Remaining indirect deprecation notices (7497x)

833x: Since symfony/doctrine-bridge 6.3: Registering "Knp\DoctrineBehaviors\EventSubscriber\BlameableEventSubscriber" as a Doctrine subscriber is deprecated. Regisr it as a listener instead, using e.g. the #[AsDoctrineListener] attribute.
...
833x: Since symfony/doctrine-bridge 6.3: Registering "Knp\DoctrineBehaviors\EventSubscriber\LoggableEventSubscriber" as a Doctrine subscriber is deprecated. Regisr it as a listener instead, using e.g. the #[AsDoctrineListener] attribute.
...
833x: Since symfony/doctrine-bridge 6.3: Registering "Knp\DoctrineBehaviors\EventSubscriber\SluggableEventSubscriber" as a Doctrine subscriber is deprecated. Regisr it as a listener instead, using e.g. the #[AsDoctrineListener] attribute.
```

```
Since symfony/doctrine-bridge 6.3: Using Doctrine subscribers as services is deprecated, declare listeners instead
```

The test suite have been run locally after the change and I could fix :

![image](https://github.com/KnpLabs/DoctrineBehaviors/assets/652505/e58b18e7-cba6-41af-a1bb-e648a6d713f3)

Fix first part of https://github.com/KnpLabs/DoctrineBehaviors/issues/737