### PR TITLE
Fix github actions

### DIFF
--- a/.github/workflows/code_checks.yaml
+++ b/.github/workflows/code_checks.yaml
@@ -32,7 +32,7 @@ jobs:
 
         steps:
             -   uses: actions/checkout@v2
-            -   uses: shivammathur/setup-php@v1
+            -   uses: shivammathur/setup-php@v2
                 with:
                     php-version: 8.0
                     extensions: pdo_sqlite, pdo_mysql, pdo_pgsql

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -13,7 +13,7 @@ jobs:
         steps:
             -   uses: actions/checkout@v2
 
-            -   uses: shivammathur/setup-php@v1
+            -   uses: shivammathur/setup-php@v2
                 with:
                     php-version: 8.0
                     extensions: pdo_sqlite, pdo_mysql, pdo_pgsql

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,7 +16,7 @@ jobs:
         steps:
             -   uses: actions/checkout@v2
 
-            -   uses: shivammathur/setup-php@v1
+            -   uses: shivammathur/setup-php@v2
                 with:
                     php-version: ${{ matrix.php }}
                     extensions: pdo_sqlite, pdo_mysql, pdo_pgsql

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "php-parallel-lint/php-parallel-lint": "^1.3",
         "phpstan/phpstan": "^1.7.10",
         "phpunit/phpunit": "^9.5",
-        "rector/rector": "^0.13.4",
+        "rector/rector": "^0.15.1",
         "symplify/easy-coding-standard": "^10.2.9",
         "symplify/phpstan-extensions": "^10.2.9",
         "phpstan/phpstan-doctrine": "^1.3",

--- a/rector.php
+++ b/rector.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\Doctrine\Set\DoctrineSetList;
 use Rector\Naming\Rector\Class_\RenamePropertyToMatchTypeRector;
-use Rector\Nette\Set\NetteSetList;
 use Rector\Php80\Rector\FunctionLike\UnionTypesRector;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
@@ -31,7 +30,6 @@ return static function (RectorConfig $rectorConfig): void {
         SetList::DEAD_CODE,
         SetList::CODE_QUALITY,
         SetList::CODING_STYLE,
-        NetteSetList::NETTE_CODE_QUALITY,
         SetList::NAMING,
         LevelSetList::UP_TO_PHP_80,
     ]);


### PR DESCRIPTION
Fix large part of the github actions. We still have an issue with rector because we use the dry-run parameter and there is some diff.

In that case, from the following commit (https://github.com/rectorphp/rector/pull/805), rector returns a Error: Process completed with exit code 2.

![image](https://github.com/KnpLabs/DoctrineBehaviors/assets/652505/01333e1d-ebc2-4f64-9c7a-fcff5d80bab9)
