### PR TITLE
Update TranslatableEventSubscriber.php

### DIFF
--- a/src/EventSubscriber/TranslatableEventSubscriber.php
+++ b/src/EventSubscriber/TranslatableEventSubscriber.php
@@ -161,7 +161,7 @@ final class TranslatableEventSubscriber implements EventSubscriberInterface
 
     private function setLocales(LifecycleEventArgs $lifecycleEventArgs): void
     {
-        $entity = $lifecycleEventArgs->getEntity();
+        $entity = $lifecycleEventArgs->getObject();
         if (! $entity instanceof TranslatableInterface) {
             return;
         }


### PR DESCRIPTION
getEntity is deprecated, use getObject()

https://github.com/doctrine/orm/issues/9875