### PR TITLE
Fixed referencedColumnName to be able to use Embedded values

### DIFF
--- a/src/EventSubscriber/TranslatableEventSubscriber.php
+++ b/src/EventSubscriber/TranslatableEventSubscriber.php
@@ -126,7 +126,7 @@ final class TranslatableEventSubscriber implements EventSubscriberInterface
             /** @var ClassMetadataInfo $classMetadata */
             $classMetadata = $objectManager->getClassMetadata($targetEntity);
 
-            $singleIdentifierFieldName = $classMetadata->getSingleIdentifierFieldName();
+            $singleIdentifierColumnName = $classMetadata->getSingleIdentifierColumnName();
 
             $classMetadataInfo->mapManyToOne([
                 'fieldName' => 'translatable',
@@ -135,7 +135,7 @@ final class TranslatableEventSubscriber implements EventSubscriberInterface
                 'fetch' => $this->translationFetchMode,
                 'joinColumns' => [[
                     'name' => 'translatable_id',
-                    'referencedColumnName' => $singleIdentifierFieldName,
+                    'referencedColumnName' => $singleIdentifierColumnName,
                     'onDelete' => 'CASCADE',
                 ]],
                 'targetEntity' => $targetEntity,

--- a/tests/Fixtures/Entity/TranslatableEmbeddableUuid.php
+++ b/tests/Fixtures/Entity/TranslatableEmbeddableUuid.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Knp\DoctrineBehaviors\Tests\Fixtures\Entity;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embeddable;
+use Doctrine\ORM\Mapping\Id;
+use Ramsey\Uuid\Uuid;
+
+#[Embeddable]
+class TranslatableEmbeddableUuid
+{
+    #[Id]
+    #[Column(name: 'uuid', unique: true)]
+    protected string $value;
+
+    public function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    public static function random(): self
+    {
+        return new self(Uuid::uuid4()->toString());
+    }
+}

--- a/tests/Fixtures/Entity/TranslatableEmbeddedIdentifierEntity.php
+++ b/tests/Fixtures/Entity/TranslatableEmbeddedIdentifierEntity.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Knp\DoctrineBehaviors\Tests\Fixtures\Entity;
+
+use Doctrine\ORM\Mapping\Embedded;
+use Doctrine\ORM\Mapping\Entity;
+use Knp\DoctrineBehaviors\Contract\Entity\TranslatableInterface;
+use Knp\DoctrineBehaviors\Model\Translatable\TranslatableTrait;
+
+#[Entity]
+class TranslatableEmbeddedIdentifierEntity implements TranslatableInterface
+{
+    use TranslatableTrait;
+
+    #[Embedded(class: TranslatableEmbeddableUuid::class, columnPrefix: false)]
+    private TranslatableEmbeddableUuid $uuid;
+
+    public function __construct()
+    {
+        $this->uuid = TranslatableEmbeddableUuid::random();
+    }
+
+    /**
+     * @param mixed[] $arguments
+     * @return mixed
+     */
+    public function __call(string $method, array $arguments)
+    {
+        return $this->proxyCurrentLocaleTranslation($method, $arguments);
+    }
+
+    public function getUuid(): TranslatableEmbeddableUuid
+    {
+        return $this->uuid;
+    }
+}

--- a/tests/Fixtures/Entity/TranslatableEmbeddedIdentifierEntityTranslation.php
+++ b/tests/Fixtures/Entity/TranslatableEmbeddedIdentifierEntityTranslation.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Knp\DoctrineBehaviors\Tests\Fixtures\Entity;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embedded;
+use Doctrine\ORM\Mapping\Entity;
+use Knp\DoctrineBehaviors\Contract\Entity\TranslationInterface;
+use Knp\DoctrineBehaviors\Model\Translatable\TranslationTrait;
+
+#[Entity]
+class TranslatableEmbeddedIdentifierEntityTranslation implements TranslationInterface
+{
+    use TranslationTrait;
+
+    #[Embedded(class: TranslatableEmbeddableUuid::class, columnPrefix: false)]
+    private TranslatableEmbeddableUuid $uuid;
+
+    #[Column(type: 'string')]
+    private ?string $title = null;
+
+    public function __construct()
+    {
+        $this->uuid = TranslatableEmbeddableUuid::random();
+    }
+
+    public function getUuid(): TranslatableEmbeddableUuid
+    {
+        return $this->uuid;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+}

--- a/tests/ORM/Translatable/TranslatableTest.php
+++ b/tests/ORM/Translatable/TranslatableTest.php
@@ -12,6 +12,7 @@ use Knp\DoctrineBehaviors\Tests\AbstractBehaviorTestCase;
 use Knp\DoctrineBehaviors\Tests\Fixtures\Contract\Translatable\TranslatableEntityWithCustomInterface;
 use Knp\DoctrineBehaviors\Tests\Fixtures\Entity\TranslatableCustomIdentifierEntity;
 use Knp\DoctrineBehaviors\Tests\Fixtures\Entity\TranslatableCustomizedEntity;
+use Knp\DoctrineBehaviors\Tests\Fixtures\Entity\TranslatableEmbeddedIdentifierEntity;
 use Knp\DoctrineBehaviors\Tests\Fixtures\Entity\TranslatableEntity;
 use Knp\DoctrineBehaviors\Tests\Fixtures\Entity\TranslatableEntityTranslation;
 use Knp\DoctrineBehaviors\Tests\Fixtures\Entity\Translation\TranslatableCustomizedEntityTranslation;
@@ -71,6 +72,27 @@ final class TranslatableTest extends AbstractBehaviorTestCase
         /** @var TranslatableEntity $translatableEntity */
         $translatableEntity = $this->entityManager->getRepository(TranslatableCustomIdentifierEntity::class)->find(
             $idColumn
+        );
+
+        $this->assertSame('awesome', $translatableEntity->translate('en')->getTitle());
+    }
+
+    public function testShouldPersistWithEmbeddedIdentifier(): void
+    {
+        $translatableEntity = new TranslatableEmbeddedIdentifierEntity();
+        $translatableEntity->translate('en')
+            ->setTitle('awesome');
+        $translatableEntity->mergeNewTranslations();
+
+        $this->entityManager->persist($translatableEntity);
+        $this->entityManager->flush();
+
+        $uuid = $translatableEntity->getUuid();
+        $this->entityManager->clear();
+
+        /** @var TranslatableEntity $translatableEntity */
+        $translatableEntity = $this->entityManager->getRepository(TranslatableEmbeddedIdentifierEntity::class)->find(
+            $uuid
         );
 
         $this->assertSame('awesome', $translatableEntity->translate('en')->getTitle());


### PR DESCRIPTION
When we are using embedded values, an error occurs when we do not receive correctly the name of the field that relates the entities, this fix corrects that problem.