### PR TITLE
Allow packages from "symfony/*" ^7

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,7 +8,7 @@ jobs:
         strategy:
             matrix:
                 php:
-                    - 8.0
+                    - 8.2
 
         name: Test ${{ matrix.php }}
         runs-on: ubuntu-latest
@@ -16,7 +16,7 @@ jobs:
         steps:
             -   uses: actions/checkout@v2
 
-            -   uses: shivammathur/setup-php@v1
+            -   uses: shivammathur/setup-php@v2
                 with:
                     php-version: ${{ matrix.php }}
                     extensions: pdo_sqlite, pdo_mysql, pdo_pgsql

--- a/composer.json
+++ b/composer.json
@@ -11,18 +11,18 @@
         { "name": "Knplabs", "homepage": "http://knplabs.com" }
     ],
     "require": {
-        "php": ">=8.0",
-        "doctrine/common": "^3.3",
+        "php": ">=8.2",
+        "doctrine/collections": "^1.6.8",
         "doctrine/persistence": "^2.5|^3.0",
         "doctrine/dbal": "^3.3",
         "doctrine/orm": "^2.12",
         "doctrine/doctrine-bundle": "^2.6",
-        "symfony/cache": "^5.4|^6.0",
-        "symfony/dependency-injection": "^5.4|^6.0",
-        "symfony/http-kernel": "^5.4|^6.0",
-        "symfony/security-core": "^5.4|^6.0",
-        "symfony/framework-bundle": "^5.4|^6.0",
-        "symfony/string": "^5.4|^6.0",
+        "symfony/cache": "^6.2|^7.0",
+        "symfony/dependency-injection": "^6.2|^7.0",
+        "symfony/http-kernel": "^6.2|^7.0",
+        "symfony/framework-bundle": "^5.4|^6.2|^7.0",
+        "symfony/security-bundle": "^6.2|^7.0",
+        "symfony/string": "^5.4|^6.2|^7.0",
         "symfony/translation-contracts": "^2.4|^3.0",
         "nette/utils": "^3.2",
         "ramsey/uuid": "^4.2"
@@ -37,14 +37,9 @@
         "phpstan/phpstan": "^1.7.10",
         "phpunit/phpunit": "^9.5",
         "rector/rector": "^0.13.4",
-        "symplify/easy-coding-standard": "^10.2.9",
-        "symplify/phpstan-extensions": "^10.2.9",
         "phpstan/phpstan-doctrine": "^1.3",
         "phpstan/phpstan-phpunit": "^1.1",
-        "symplify/package-builder": "^10.2.9",
-        "symplify/phpstan-rules": "^10.2.9",
-        "phpstan/extension-installer": "^1.1",
-        "symplify/easy-ci": "^10.2.9"
+        "phpstan/extension-installer": "^1.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/Provider/UserProvider.php
+++ b/src/Provider/UserProvider.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Knp\DoctrineBehaviors\Provider;
 
 use Knp\DoctrineBehaviors\Contract\Provider\UserProviderInterface;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Bundle\SecurityBundle\Security;
 
 final class UserProvider implements UserProviderInterface
 {

--- a/tests/config/config_test.php
+++ b/tests/config/config_test.php
@@ -9,8 +9,8 @@ use Knp\DoctrineBehaviors\Tests\DatabaseLoader;
 use Knp\DoctrineBehaviors\Tests\Provider\TestLocaleProvider;
 use Knp\DoctrineBehaviors\Tests\Provider\TestUserProvider;
 use Psr\Log\Test\TestLogger;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use Symfony\Component\Security\Core\Security;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $containerConfigurator): void {


### PR DESCRIPTION
This PR also addresses changes from previous PRs:
- #739;
- #727.

Please, be aware that I'm not currently using this package, but these changes are required to allow `symfony/*: ^7` in other packages (see https://github.com/sonata-project/SonataTranslationBundle/pull/700#issuecomment-1858815493).

Additionally, I think this requires tests, because some of the changes made here are not currently covered.
Even, AFAIK, the lowest dependencies in the CI pipeline are not being checked.

