### PR TITLE
Set return type for offsetGet method

### DIFF
--- a/src/Model/Tree/TreeNodeMethodsTrait.php
+++ b/src/Model/Tree/TreeNodeMethodsTrait.php
@@ -268,10 +268,7 @@ trait TreeNodeMethodsTrait
         unset($this->getChildNodes()[$offset]);
     }
 
-    /**
-     * @return mixed
-     */
-    public function offsetGet(mixed $offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->getChildNodes()[$offset];
     }


### PR DESCRIPTION
to avoid deprecate notice


`Deprecated: Return type of offsetGet(mixed $offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice.`