### PR TITLE
Fix dynamically declared property deprecation in TreeNodeMethodsTrait

### DIFF
--- a/src/Contract/Entity/TreeNodeInterface.php
+++ b/src/Contract/Entity/TreeNodeInterface.php
@@ -40,7 +40,7 @@ interface TreeNodeInterface
     public function setParentNode(self $treeNode): void;
 
     /**
-     * @param string $path the materialized path, eg: the the materialized path to its parent
+     * @param string $path the materialized path, eg: the materialized path to its parent
      */
     public function setMaterializedPath(string $path): void;
 

--- a/src/Model/Tree/TreeNodeMethodsTrait.php
+++ b/src/Model/Tree/TreeNodeMethodsTrait.php
@@ -57,7 +57,6 @@ trait TreeNodeMethodsTrait
 
     public function setParentMaterializedPath(string $path): void
     {
-        $this->parentNodePath = $path;
     }
 
     public function getRootMaterializedPath(): string


### PR DESCRIPTION
The property is only set but never retrieved, so the assignment can be safely removed.