### PR TITLE
Prepare 3.0 release

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,26 +2,50 @@ name: Code Tests
 
 on:
     pull_request: null
+    push:
+        branches:
+            - master
 
 jobs:
     tests:
         strategy:
             matrix:
-                php:
-                    - 8.1
+                php: ['8.1', '8.2', '8.3', '8.4']
+                deps: ['stable']
+                symfony: [ '' ] # Don't lock to a specific symfony version by default
+                include:
+                    # Test lowest dependencies
+                    -   deps: 'lowest'
+                        php: '8.1'
+                    # Test latest php with LTS version.
+                    -   deps: 'lts'
+                        php: '8.4'
+                        symfony: '^6.4'
 
-        name: Test ${{ matrix.php }}
+        name: "${{ matrix.deps }} | PHP ${{ matrix.php }} ${{ matrix.symfony != '' && format('| Symfony {0}', matrix.symfony) || '' }}"
         runs-on: ubuntu-latest
 
         steps:
             -   uses: actions/checkout@v2
 
+            -   name: Set-up env variables
+                run: |
+                    case "${{ matrix.deps }}" in
+                     "lowest")
+                       echo "COMPOSER_FLAGS=--prefer-lowest" >> $GITHUB_ENV
+                       echo "SYMFONY_REQUIRE=$(echo '${{ matrix.symfony }}')" >> $GITHUB_ENV
+                       ;;
+                     *)
+                       echo "SYMFONY_REQUIRE=$(echo '${{ matrix.symfony }}')" >> $GITHUB_ENV
+                    esac
+
             -   uses: shivammathur/setup-php@v2
                 with:
                     php-version: ${{ matrix.php }}
                     extensions: pdo_sqlite, pdo_mysql, pdo_pgsql
+                    tools: flex
                     coverage: none
 
-            -   run: composer install --no-progress
+            -   run: composer update --prefer-dist --no-progress $COMPOSER_FLAGS
 
             -   run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,11 @@
     "require": {
         "php": ">=8.1",
         "doctrine/common": "^3.3",
+        "doctrine/collections": "^2.1.2",
         "doctrine/persistence": "^2.5|^3.0|^4.0",
         "doctrine/dbal": "^3.8.0|^4.1",
         "doctrine/orm": "^2.12|^3.0.0",
-        "doctrine/doctrine-bundle": "^2.7.2",
+        "doctrine/doctrine-bundle": "^2.16",
         "symfony/cache": "^6.4|^7.2",
         "symfony/dependency-injection": "^6.4|^7.2",
         "symfony/http-kernel": "^6.4|^7.2",
@@ -25,7 +26,7 @@
         "symfony/string": "^6.4|^7.2",
         "symfony/translation-contracts": "^2.4|^3.0",
         "nette/utils": "^3.2|^4.0",
-        "ramsey/uuid": "^4.2"
+        "ramsey/uuid": "^4.3"
     },
     "require-dev": {
         "ext-pdo_sqlite": "*",
@@ -35,7 +36,7 @@
         "doctrine/annotations": "^2.0.1",
         "php-parallel-lint/php-parallel-lint": "^1.3",
         "phpstan/phpstan": "^2.1",
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "rector/rector": "^2.1",
         "symplify/easy-coding-standard": "^12.6",
         "symplify/phpstan-extensions": "^12.0",
@@ -43,7 +44,8 @@
         "phpstan/phpstan-phpunit": "^2.0",
         "symplify/phpstan-rules": "^14.7",
         "phpstan/extension-installer": "^1.4.3",
-        "symplify/easy-ci": "^12.1"
+        "symplify/easy-ci": "^12.1",
+        "symfony/phpunit-bridge": "^7.3"
     },
     "autoload": {
         "psr-4": {
@@ -72,6 +74,9 @@
             "includes": [
                 "phpstan-extension.neon"
             ]
+        },
+        "branch-alias": {
+            "dev-main": "3.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "doctrine/annotations": "^2.0.1",
         "php-parallel-lint/php-parallel-lint": "^1.3",
         "phpstan/phpstan": "^2.1",
-        "phpunit/phpunit": "^9.6",
+        "phpunit/phpunit": "^10.5",
         "rector/rector": "^2.1",
         "symplify/easy-coding-standard": "^12.6",
         "symplify/phpstan-extensions": "^12.0",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,4 +9,8 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
+
+    <listeners>
+        <listener class="\Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+    </listeners>
 </phpunit>

--- a/src/Model/Translatable/TranslationMethodsTrait.php
+++ b/src/Model/Translatable/TranslationMethodsTrait.php
@@ -48,7 +48,7 @@ trait TranslationMethodsTrait
                 continue;
             }
 
-            if (is_string($value) && strlen(trim($value)) > 0) {
+            if (is_string($value) && trim($value) !== '') {
                 return false;
             }
 

--- a/tests/Fixtures/Entity/SoftDeletable/SoftDeletableEntity.php
+++ b/tests/Fixtures/Entity/SoftDeletable/SoftDeletableEntity.php
@@ -16,7 +16,7 @@ use Knp\DoctrineBehaviors\Model\SoftDeletable\SoftDeletableTrait;
 #[Entity]
 #[InheritanceType(value: 'SINGLE_TABLE')]
 #[DiscriminatorMap(value: [
-    'mainclass' => \Knp\DoctrineBehaviors\Tests\Fixtures\Entity\SoftDeletable\SoftDeletableEntity::class,
+    'mainclass' => SoftDeletableEntity::class,
     'subclass' => SoftDeletableEntityInherit::class,
 ])]
 class SoftDeletableEntity implements SoftDeletableInterface

--- a/tests/ORM/Sluggable/SluggableTest.php
+++ b/tests/ORM/Sluggable/SluggableTest.php
@@ -63,7 +63,7 @@ final class SluggableTest extends AbstractBehaviorTestCase
         $this->assertSame($expectedSlug, $sluggableEntity->getSlug());
     }
 
-    public function provideDataForTest(): Iterator
+    public static function provideDataForTest(): Iterator
     {
         yield ['The name', 'the-name'];
         yield ['Löic & René', 'loic-rene'];

--- a/tests/ORM/TreeNodeTest.php
+++ b/tests/ORM/TreeNodeTest.php
@@ -70,7 +70,7 @@ final class TreeNodeTest extends AbstractBehaviorTestCase
 
     public function testIsRoot(): void
     {
-        $treeNodeEntity = $this->buildTree();
+        $treeNodeEntity = self::buildTree();
 
         $this->assertTrue($treeNodeEntity->getRootNode()->isRootNode());
         $this->assertTrue($treeNodeEntity->isRootNode());
@@ -78,7 +78,7 @@ final class TreeNodeTest extends AbstractBehaviorTestCase
 
     public function testIsLeaf(): void
     {
-        $treeNodeEntity = $this->buildTree();
+        $treeNodeEntity = self::buildTree();
 
         $this->assertTrue($treeNodeEntity[0][0][0]->isLeafNode());
         $this->assertTrue($treeNodeEntity[1]->isLeafNode());
@@ -86,7 +86,7 @@ final class TreeNodeTest extends AbstractBehaviorTestCase
 
     public function testGetRoot(): void
     {
-        $treeNodeEntity = $this->buildTree();
+        $treeNodeEntity = self::buildTree();
 
         $this->assertSame($treeNodeEntity, $treeNodeEntity->getRootNode());
         $this->assertNull($treeNodeEntity->getRootNode()->getParentNode());
@@ -123,9 +123,9 @@ final class TreeNodeTest extends AbstractBehaviorTestCase
         $this->assertSame($expected, $child->isChildNodeOf($parent));
     }
 
-    public function provideIsChildNodeOf(): Iterator
+    public static function provideIsChildNodeOf(): Iterator
     {
-        $treeNodeEntity = $this->buildTree();
+        $treeNodeEntity = self::buildTree();
 
         yield [$treeNodeEntity[0][0], $treeNodeEntity[0], true];
         yield [$treeNodeEntity[0][0][0], $treeNodeEntity[0][0], true];
@@ -165,7 +165,7 @@ final class TreeNodeTest extends AbstractBehaviorTestCase
     public function testToArray(): void
     {
         $expected = $this->provideToArray();
-        $treeNodeEntity = $this->buildTree();
+        $treeNodeEntity = self::buildTree();
 
         $this->assertSame($expected, $treeNodeEntity->toArray());
     }
@@ -173,7 +173,7 @@ final class TreeNodeTest extends AbstractBehaviorTestCase
     public function testToJson(): void
     {
         $expected = $this->provideToArray();
-        $treeNodeEntity = $this->buildTree();
+        $treeNodeEntity = self::buildTree();
         $this->assertSame(Json::encode($expected), $treeNodeEntity->toJson());
     }
 
@@ -192,7 +192,7 @@ final class TreeNodeTest extends AbstractBehaviorTestCase
 
     public function testArrayAccess(): void
     {
-        $tree = $this->buildTree();
+        $tree = self::buildTree();
 
         $treeNodeEntity45 = new TreeNodeEntity();
         $treeNodeEntity45->setId(45);
@@ -264,7 +264,7 @@ final class TreeNodeTest extends AbstractBehaviorTestCase
 
     public function testChildrenCount(): void
     {
-        $treeNodeEntity = $this->buildTree();
+        $treeNodeEntity = self::buildTree();
 
         $this->assertCount(2, $treeNodeEntity->getChildNodes());
         $this->assertCount(1, $treeNodeEntity->getChildNodes()->get(0)->getChildNodes());
@@ -272,7 +272,7 @@ final class TreeNodeTest extends AbstractBehaviorTestCase
 
     public function testGetPath(): void
     {
-        $treeNodeEntity = $this->buildTree();
+        $treeNodeEntity = self::buildTree();
 
         $this->assertSame('/1', $treeNodeEntity->getRealMaterializedPath());
         $this->assertSame('/1/2', $treeNodeEntity->getChildNodes()->get(0)->getRealMaterializedPath());
@@ -321,7 +321,7 @@ final class TreeNodeTest extends AbstractBehaviorTestCase
 
     public function testMoveChildren(): void
     {
-        $treeNodeEntity = $this->buildTree();
+        $treeNodeEntity = self::buildTree();
 
         $childChildItem = $treeNodeEntity->getChildNodes()
             ->get(0)
@@ -376,7 +376,7 @@ final class TreeNodeTest extends AbstractBehaviorTestCase
         $this->assertSame($tree[0][0], $entity[0][0]);
     }
 
-    private function buildTree(): TreeNodeEntity
+    private static function buildTree(): TreeNodeEntity
     {
         $item = new TreeNodeEntity();
         $item->setMaterializedPath('');

--- a/tests/Repository/DefaultSluggableRepositoryTest.php
+++ b/tests/Repository/DefaultSluggableRepositoryTest.php
@@ -63,14 +63,32 @@ final class DefaultSluggableRepositoryTest extends TestCase
             ->with($entityClass, 'e')
             ->willReturnSelf();
 
-        $queryBuilder->expects(self::exactly(2))
+        $invokedCount = $this->exactly(2);
+        $queryBuilder->expects($invokedCount)
             ->method('andWhere')
-            ->withConsecutive(['e.slug = :slug'], ['e.id.id != :id_id'])
+            ->willReturnCallback(function ($parameters) use ($invokedCount) {
+                if ($invokedCount->numberOfInvocations() === 1) {
+                    $this->assertSame(['e.slug = :slug'], $parameters);
+                }
+
+                if ($invokedCount->numberOfInvocations() === 2) {
+                    $this->assertSame(['e.id.id != :id_id'], $parameters);
+                }
+            })
             ->willReturnSelf();
 
-        $queryBuilder->expects(self::exactly(2))
+        $invokedCount = $this->exactly(2);
+        $queryBuilder->expects($invokedCount)
             ->method('setParameter')
-            ->withConsecutive(['slug', $uniqueSlug], ['id_id', '123'])
+            ->willReturnCallback(function ($parameters) use ($invokedCount, $uniqueSlug) {
+                if ($invokedCount->numberOfInvocations() === 1) {
+                    $this->assertSame(['slug', $uniqueSlug], $parameters);
+                }
+
+                if ($invokedCount->numberOfInvocations() === 2) {
+                    $this->assertSame(['id_id', '123'], $parameters);
+                }
+            })
             ->willReturnSelf();
 
         $queryBuilder->expects(self::once())

--- a/tests/config/config_test.php
+++ b/tests/config/config_test.php
@@ -13,9 +13,44 @@ use Knp\DoctrineBehaviors\Tests\Utils\Doctrine\DebugStack;
 use Psr\Log\Test\TestLogger;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\HttpKernel\Kernel;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->extension('framework', [
+        'http_method_override' => false,
+        'handle_all_throwables' => true,
+        'php_errors' => [
+            'log' => true,
+        ],
+    ]);
+
+    if (Kernel::VERSION_ID >= 70300) { // @phpstan-ignore greaterOrEqual.alwaysFalse
+        $containerConfigurator->extension('framework', [
+            'property_info' => [
+                'with_constructor_extractor' => true,
+            ],
+        ]);
+    }
+
+    $containerConfigurator->extension('doctrine', [
+        'orm' => [
+            'enable_lazy_ghost_objects' => true,
+            'controller_resolver' => [
+                'auto_mapping' => false,
+            ],
+        ],
+    ]);
+
+    if (PHP_VERSION_ID >= 80400) {
+        $containerConfigurator->extension('doctrine', [
+            'orm' => [
+                'enable_lazy_ghost_objects' => true,
+                'enable_native_lazy_objects' => true,
+            ],
+        ]);
+    }
+
     $parameters = $containerConfigurator->parameters();
 
     $parameters->set('env(DB_ENGINE)', 'pdo_sqlite');


### PR DESCRIPTION
Prepare the 3.0 release and improve the test setup

* Expanded the GitHub Actions test matrix to cover PHP versions 8.1 through 8.4, test with different dependency sets (stable, lowest, LTS)
* Fix test deprecations with various dependency and php versions
